### PR TITLE
Added handling of ParseError to get_authn_response()

### DIFF
--- a/src/eduid_common/authn/eduid_saml2.py
+++ b/src/eduid_common/authn/eduid_saml2.py
@@ -36,6 +36,8 @@ from saml2.client import Saml2Client
 from saml2.saml import AuthnContextClassRef
 from saml2.samlp import RequestedAuthnContext
 
+from xml.etree.ElementTree import ParseError
+
 from .cache import IdentityCache, OutstandingQueriesCache, StateCache
 from .utils import get_saml2_config, get_saml_attribute
 
@@ -122,6 +124,12 @@ def get_authn_response(config, session, raw_response):
             """SAML response is not verified. May be caused by the response
             was not issued at a reasonable time or the SAML status is not ok.
             Check the IDP datetime setup""")
+    except ParseError as e:
+        logger.error('SAML response is not correctly formatted: {!r}'.format(e))
+        raise BadSAMLResponse(
+            """SAML response is not correctly formatted and therefore the
+            XML document could not be parsed.
+            """)
 
     if response is None:
         logger.error('SAML response is None')

--- a/src/eduid_common/session/session.py
+++ b/src/eduid_common/session/session.py
@@ -216,7 +216,7 @@ class Session(collections.MutableMapping):
         _encrypted_data = None
         if data is None:
             if not (token or session_id):
-                raise ValueError('Data must be provided when token/session_id is not')
+                raise ValueError('Data must be provided when token/session_id is not provided')
 
             logger.debug('Looking for session using token {!r} or session_id {!r}'.format(token, session_id))
 


### PR DESCRIPTION
The more specific exception is handled here and then a more generic BadSAMLResponse is raised that, for example, Dashboard can handle.