### PR TITLE
Eperez input validation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ webapp_requires = [
     'vccs_client >= 0.4.1',
     'PyNaCl >= 1.0.1',
     'python-etcd >= 0.4.3',
-    'PyYAML >= 3.11'
+    'PyYAML >= 3.11',
+    'bleach>=1.4.2',
 ]
 webapp_extras = webapp_requires + []
 

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ requires = [
 
 # Flavours
 webapp_requires = [
+    'Flask==0.10.1',
     'pysaml2 >= 4.0.3rc1',  # version sync with dashboard to avoid pip catastrophes
     'redis >= 2.10.5',
     'pwgen == 0.4',

--- a/src/eduid_common/api/app.py
+++ b/src/eduid_common/api/app.py
@@ -37,6 +37,7 @@ it with all attributes common to all eduID services.
 
 from eduid_userdb import UserDB
 from eduid_common.authn.middleware import AuthnApp
+from eduid_common.api.request import Request
 from eduid_common.api.session import SessionFactory
 from eduid_common.api.logging import init_logging
 from eduid_common.api.exceptions import init_exception_handlers, init_sentry
@@ -67,6 +68,7 @@ def eduid_init_app(name, config, app_class=AuthnApp):
     :rtype: flask.Flask
     """
     app = app_class(name)
+    app.request_class = Request
 
     # Init etcd config parsers
     common_parser = EtcdConfigParser('/eduid/webapp/common/')

--- a/src/eduid_common/api/request.py
+++ b/src/eduid_common/api/request.py
@@ -71,6 +71,18 @@ class SanitationMixin(object):
         :type untrusted_text: str | unicode
         :rtype: str | unicode
         """
+        try:
+            return self._sanitize_input(untrusted_text,
+                                        strip_characters=strip_characters,
+                                        percent_encoded=percent_encoded)
+        except UnicodeDecodeError:
+            logger.warn('A malicious user tried to crash the application '
+                        'by sending non-unicode input in a GET request')
+            raise abort(400)
+
+    def _sanitize_input(self, untrusted_text, strip_characters=False,
+                       percent_encoded=False):
+
         if untrusted_text is None:
             # If we are given None then there's nothing to clean
             return None

--- a/src/eduid_common/api/request.py
+++ b/src/eduid_common/api/request.py
@@ -29,6 +29,27 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
+"""
+This module provides a Request class that extends flask.Request
+and adds sanitation to user inputs. This sanitation is performed
+on the methods of the datastructures that the request uses to
+hold data inputs by the user.
+Since those methods need to know the content_type header sent by
+users, the datastructure classes' constructors accept a first
+argument with the content type, and in the constructor for the
+request, where we have the content type, the datastructure classes
+constructors are partially applied with the content type, so then
+when the request implements those classes, they already know the
+content type.
+
+To use this request, assign it to the `request_class` attribute
+of the Flask application::
+
+    >>> from eduid_common.api.request import Request
+    >>> from flask import Flask
+    >>> app = Flask('name')
+    >>> app.request_class =  Request
+"""
 
 from bleach import clean
 from urllib import unquote, quote

--- a/src/eduid_common/api/request.py
+++ b/src/eduid_common/api/request.py
@@ -57,10 +57,6 @@ from werkzeug.datastructures import EnvironHeaders
 from flask import Request as BaseRequest
 from flask import abort, current_app
 
-# XXX there is a logging module in this package that interferes with th one in the standard library
-from logging import logging
-logger = logging.getLogger(__name__)
-
 
 class SanitationMixin(object):
     """
@@ -87,7 +83,7 @@ class SanitationMixin(object):
             return self._sanitize_input(untrusted_text,
                                         strip_characters=strip_characters)
         except UnicodeDecodeError:
-            logger.warn('A malicious user tried to crash the application '
+            current_app.logger.warn('A malicious user tried to crash the application '
                         'by sending non-unicode input in a GET request')
             abort(400)
 
@@ -127,7 +123,7 @@ class SanitationMixin(object):
         try:
             return clean(untrusted_text, strip=strip_characters)
         except KeyError:
-            logger.warn('A malicious user tried to crash the application by '
+            current_app.logger.warn('A malicious user tried to crash the application by '
                         'sending illegal UTF-8 in an URI or other untrusted '
                         'user input.')
             abort(400)

--- a/src/eduid_common/api/request.py
+++ b/src/eduid_common/api/request.py
@@ -32,8 +32,9 @@
 """
 This module provides a Request class that extends flask.Request
 and adds sanitation to user inputs. This sanitation is performed
-on the methods of the datastructures that the request uses to
+on the access methods of the datastructures that the request uses to
 hold data inputs by the user.
+For more information on these structures, see werkzeug.datastructures.
 
 To use this request, assign it to the `request_class` attribute
 of the Flask application::
@@ -233,10 +234,27 @@ class SanitizedTypeConversionDict(ImmutableTypeConversionDict, SanitationMixin):
     """
 
     def __getitem__(self, key):
+        """
+        Sanitized __getitem__
+        """
         val = ImmutableTypeConversionDict.__getitem__(self, key)
         return self.sanitize_input(val)
 
     def get(self, key, default=None, type=None):
+        """
+        Sanitized, type conversion get.
+        The value identified by `key` is sanitized, and if `type`
+        is provided, the value is cast to it.
+
+        :param key: the key for the value
+        :type key: str
+        :para default: the default if `key` is absent
+        :type default: str
+        :param type: The type to cast  the value
+        :type type: type
+
+        :rtype: object
+        """
         try:
             val = self.sanitize_input(self[key])
             if type is not None:
@@ -246,14 +264,26 @@ class SanitizedTypeConversionDict(ImmutableTypeConversionDict, SanitationMixin):
         return val
 
     def values(self):
+        """
+        sanitized values
+        """
         return [self.sanitize_input(v) for v in
                 ImmutableTypeConversionDict.values(self)]
 
     def items(self):
+        """
+        Sanitized items
+        """
         return [(v[0], self.sanitize_input(v[1])) for v in
                 ImmutableTypeConversionDict.items(self)]
 
     def pop(self, key):
+        """
+        Sanitized pop
+
+        :param key: the key for the value
+        :type key: str
+        """
         val = ImmutableTypeConversionDict.pop(key)
         return self.sanitize_input(val)
 
@@ -264,10 +294,22 @@ class SanitizedEnvironHeaders(EnvironHeaders, SanitationMixin):
     """
 
     def __getitem__(self, key, _get_mode=False):
+        """
+        Sanitized __getitem__
+
+        :param key: the key for the value
+        :type key: str
+        :param _get_mode: is a no-op for this class as there is no index but
+                          used because get() calls it.
+        :type _get_mode: bool
+        """
         val = EnvironHeaders.__getitem__(self, key, _get_mode=_get_mode)
         return self.sanitize_input(val)
 
     def __iter__(self):
+        """
+        Sanitized __iter__
+        """
         for val in EnvironHeaders.__iter__(self):
             yield self.sanitize_input(val)
 

--- a/src/eduid_common/api/request.py
+++ b/src/eduid_common/api/request.py
@@ -1,0 +1,270 @@
+#
+# Copyright (c) 2016 NORDUnet A/S
+# All rights reserved.
+#
+#   Redistribution and use in source and binary forms, with or
+#   without modification, are permitted provided that the following
+#   conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#     2. Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided
+#        with the distribution.
+#     3. Neither the name of the NORDUnet nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+from bleach import clean
+from urllib import unquote, quote
+from functools import partial
+
+from werkzeug._compat import iteritems, itervalues
+from werkzeug.datastructures import ImmutableMultiDict
+
+from flask import Request as BaseRequest
+from flask import abort
+
+# XXX there is a logging module in this package that interferes with th one in the standard library
+from logging import logging
+logger = logging.getLogger(__name__)
+
+
+class SanitationMixin(object):
+    """
+    Mixin for werkzeug datastructures providing methods to
+    sanitize user inputs.
+    """
+
+    def sanitize_input(self, untrusted_text, strip_characters=False,
+                       percent_encoded=False):
+        """
+        Sanitize user input by escaping or removing potentially
+        harmful input using a whitelist-based approach with
+        bleach as recommended by OWASP.
+
+        :param untrusted_text User input to sanitize
+        :param strip_characters Set to True to remove instead of escaping
+                                potentially harmful input.
+
+        :param percent_encoded Set to True if the input should be treated
+                               as percent encoded if no content type is
+                               already defined.
+
+        :return: Sanitized user input
+
+        :type untrusted_text: str | unicode
+        :rtype: str | unicode
+        """
+        if untrusted_text is None:
+            # If we are given None then there's nothing to clean
+            return None
+
+        # Decide on whether or not to use percent encoding:
+        # 1. Check if the content type has been explicitly set
+        # 2. If set, use percent encoding if requested by the client
+        # 3. If the content type has not been explicitly set,
+        # 3.1 use percent encoding according to the calling
+        #    functions preference or,
+        # 3.2 use the default value as set in the function definition.
+        if self.content_type is not None:
+
+            if self.content_type == "application/x-www-form-urlencoded":
+                use_percent_encoding = True
+            else:
+                use_percent_encoding = False
+
+        else:
+            use_percent_encoding = percent_encoded
+
+        if use_percent_encoding:
+            # If the untrusted_text is percent encoded we have to:
+            # 1. Decode it so we can process it.
+            # 2. Encode it to UTF-8 since bleach assumes this encoding
+            # 3. Clean it to remove dangerous characters.
+            # 4. Percent encode it before returning it back.
+
+            decoded_text = unquote(untrusted_text)
+
+            if not isinstance(decoded_text, unicode):
+                decoded_text_in_utf8 = decoded_text.encode("UTF-8")
+            else:
+                decoded_text_in_utf8 = decoded_text
+
+            cleaned_text = self._safe_clean(decoded_text_in_utf8, strip_characters)
+            percent_encoded_text = quote(cleaned_text)
+
+            if decoded_text_in_utf8 != cleaned_text:
+                logger.warn('Some potential harmful characters were '
+                            'removed from untrusted user input.')
+
+            return percent_encoded_text
+
+        # If the untrusted_text is not percent encoded we only have to:
+        # 1. Encode it to UTF-8 since bleach assumes this encoding
+        # 2. Clean it to remove dangerous characters.
+
+        if not isinstance(untrusted_text, unicode):
+            text_in_utf8 = untrusted_text.encode("UTF-8")
+        else:
+            text_in_utf8 = untrusted_text
+
+        cleaned_text = self._safe_clean(text_in_utf8, strip_characters)
+
+        if text_in_utf8 != cleaned_text:
+            logger.warn('Some potential harmful characters were '
+                        'removed from untrusted user input.')
+
+        return cleaned_text
+
+    def _safe_clean(self, untrusted_text, strip_characters=False):
+        """
+        Wrapper for the clean function of bleach to be able
+        to catch when illegal UTF-8 is processed.
+
+        :param untrusted_text: Text to sanitize
+        :param strip_characters: Set to True to remove instead of escaping
+        :return: Sanitized text
+
+        :type untrusted_text: str | unicode
+        :rtype: str | unicode
+        """
+        try:
+            return clean(untrusted_text, strip=strip_characters)
+        except KeyError:
+            logger.warn('A malicious user tried to crash the application by '
+                        'sending illegal UTF-8 in an URI or other untrusted '
+                        'user input.')
+            abort(400)
+
+
+class SanitizedImmutableMultiDict(ImmutableMultiDict, SanitationMixin):
+    """
+    See `werkzeug.datastructures.ImmutableMultiDict`.
+    This class is an extension that overrides all "getter" methods to
+    sanitize the extracted data.
+    """
+
+    def __init__(self, content_type, mapping=None):
+        """
+        :param content_type: Set to decide on the use of percent encoding
+                             according to the content type.
+        :param mapping: the initial value for the :class:`MultiDict`.  Either a
+                        regular dict, an iterable of ``(key, value)`` tuples
+                        or `None`.
+        """
+        self.content_type = content_type or None
+        super(SanitizedImmutableMultiDict, self).__init__(mapping=mapping)
+
+    def __getitem__(self, key):
+        """
+        Return the first data value for this key;
+        raises KeyError if not found.
+
+        :param key: The key to be looked up.
+        :raise KeyError: if the key does not exist.
+        """
+        value = super(SanitizedImmutableMultiDict, self).__getitem__(key)
+        return self.sanitize_input(value)
+
+    def getlist(self, key, type=None):
+        """
+        Return the list of items for a given key. If that key is not in the
+        `MultiDict`, the return value will be an empty list.  Just as `get`
+        `getlist` accepts a `type` parameter.  All items will be converted
+        with the callable defined there.
+
+        :param key: The key to be looked up.
+        :param type: A callable that is used to cast the value in the
+                     :class:`MultiDict`.  If a :exc:`ValueError` is raised
+                     by this callable the value will be removed from the list.
+        :return: a :class:`list` of all the values for the key.
+        """
+        value_list = super(SanitizedImmutableMultiDict, self).getlist(key, type=type)
+        return [self.sanitize_input(v) for v in value_list]
+
+    def items(self, multi=False):
+        """
+        Return an iterator of ``(key, value)`` pairs.
+
+        :param multi: If set to `True` the iterator returned will have a pair
+                      for each value of each key.  Otherwise it will only
+                      contain pairs for the first value of each key.
+        """
+        for key, values in iteritems(dict, self):
+            values = [self.sanitize_input(v) for v in values]
+            if multi:
+                for value in values:
+                    yield key, value
+            else:
+                yield key, values[0]
+
+    def lists(self):
+        """Return a list of ``(key, values)`` pairs, where values is the list
+        of all values associated with the key."""
+
+        for key, values in iteritems(dict, self):
+            values = [self.sanitize_input(v) for v in values]
+            yield key, values
+
+    def values(self):
+        """
+        Returns an iterator of the first value on every key's value list.
+        """
+        for values in itervalues(dict, self):
+            yield self.sanitize_input(values[0])
+
+    def listvalues(self):
+        """
+        Return an iterator of all values associated with a key.  Zipping
+        :meth:`keys` and this is the same as calling :meth:`lists`:
+
+        >>> d = MultiDict({"foo": [1, 2, 3]})
+        >>> zip(d.keys(), d.listvalues()) == d.lists()
+        True
+        """
+        for values in itervalues(dict, self):
+            yield (self.sanitize_input(v) for v in values)
+
+    def to_dict(self, flat=True):
+        """Return the contents as regular dict.  If `flat` is `True` the
+        returned dict will only have the first item present, if `flat` is
+        `False` all values will be returned as lists.
+
+        :param flat: If set to `False` the dict returned will have lists
+                     with all the values in it.  Otherwise it will only
+                     contain the first value for each key.
+        :return: a :class:`dict`
+        """
+        if flat:
+            d = {}
+            for k, v in iteritems(self):
+                v = self.sanitize_input(v)
+                d[k] = v
+            return d
+        return dict(self.lists())
+
+
+class Request(BaseRequest):
+    """
+    Request objects with sanitized inputs
+    """
+    def __init__(self, *args, **kwargs):
+        super(Request, self).__init__(*args, **kwargs)
+        psc = partial(SanitizedImmutableMultiDict, self.content_type)
+        self.parameter_storage_class = psc

--- a/src/eduid_common/api/tests/__init__.py
+++ b/src/eduid_common/api/tests/__init__.py
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2016 NORDUnet A/S
+# All rights reserved.
+#
+#   Redistribution and use in source and binary forms, with or
+#   without modification, are permitted provided that the following
+#   conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#     2. Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided
+#        with the distribution.
+#     3. Neither the name of the NORDUnet nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#

--- a/src/eduid_common/api/tests/test_inputs.py
+++ b/src/eduid_common/api/tests/test_inputs.py
@@ -1,0 +1,95 @@
+#
+# Copyright (c) 2016 NORDUnet A/S
+# All rights reserved.
+#
+#   Redistribution and use in source and binary forms, with or
+#   without modification, are permitted provided that the following
+#   conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#     2. Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided
+#        with the distribution.
+#     3. Neither the name of the NORDUnet nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+from flask import Flask, Blueprint
+from flask import request
+from flask import make_response
+
+from eduid_common.api.testing import EduidAPITestCase
+from eduid_common.api.session import SessionFactory
+from eduid_userdb import UserDB
+
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+test_views = Blueprint('test', __name__)
+
+
+@test_views.route('/test-get-param', methods=['GET'])
+def get_param_view():
+    param = request.args.get('test-param')
+    html = '<html><body>{}</body></html>'.format(param)
+    response = make_response(html, 200)
+    response.headers['Content-Type'] = "text/html; charset=utf8"
+    return response
+
+
+class InputsTests(EduidAPITestCase):
+
+    def update_config(self, config):
+        """
+        Called from the parent class, so that we can update the configuration
+        according to the needs of this test case.
+        """
+        config.update({
+            })
+        return config
+
+    def load_app(self, config):
+        """
+        Called from the parent class, so we can provide the appropriate flask
+        app for this test case.
+        """
+        app = Flask('test.localhost')
+        app.config.update(config)
+        app.register_blueprint(test_views)
+        app.central_userdb = UserDB(app.config['MONGO_URI'], 'eduid_am')
+        app.session_interface = SessionFactory(app.config)
+        return app
+
+    def test_get_param(self):
+        """"""
+        url = '/test-get-param?test-param=test-param'
+        with self.app.test_request_context(url, method='GET'):
+
+            response = self.app.dispatch_request()
+            self.assertIn('test-param', response.data)
+
+    def test_get_param_script(self):
+        """"""
+        url = '/test-get-param?test-param=<script>alert("ho")</script>'
+        with self.app.test_request_context(url, method='GET'):
+
+            response = self.app.dispatch_request()
+            self.assertNotIn('<script>', response.data)

--- a/src/eduid_common/api/tests/test_inputs.py
+++ b/src/eduid_common/api/tests/test_inputs.py
@@ -124,10 +124,9 @@ class InputsTests(EduidAPITestCase):
             response = self.app.dispatch_request()
             self.assertNotIn('<script>', response.data)
 
-    def test_post_param_script(self):
+    def test_cookie_script(self):
         """"""
         url = '/test-cookie'
-
         cookie = dump_cookie('test-cookie', '<script>alert("ho")</script>')
         with self.app.test_request_context(url, method='GET',
                                            headers={'Cookie': cookie}):

--- a/src/eduid_common/api/tests/test_inputs.py
+++ b/src/eduid_common/api/tests/test_inputs.py
@@ -1,3 +1,4 @@
+#  -*- encoding: utf-8 -*-
 #
 # Copyright (c) 2016 NORDUnet A/S
 # All rights reserved.
@@ -75,6 +76,15 @@ def cookie_view():
     return response
 
 
+@test_views.route('/test-header')
+def header_view():
+    test_header = request.headers.get('X-TEST')
+    html = '<html><body>{}</body></html>'.format(test_header)
+    response = make_response(html, 200)
+    response.headers['Content-Type'] = "text/html; charset=utf8"
+    return response
+
+
 class InputsTests(EduidAPITestCase):
 
     def update_config(self, config):
@@ -130,6 +140,16 @@ class InputsTests(EduidAPITestCase):
         cookie = dump_cookie('test-cookie', '<script>alert("ho")</script>')
         with self.app.test_request_context(url, method='GET',
                                            headers={'Cookie': cookie}):
+
+            response = self.app.dispatch_request()
+            self.assertNotIn('<script>', response.data)
+
+    def test_header_script(self):
+        """"""
+        url = '/test-header'
+        script = '<script>alert("ho")</script>'
+        with self.app.test_request_context(url, method='GET',
+                                           headers={'X-TEST': script}):
 
             response = self.app.dispatch_request()
             self.assertNotIn('<script>', response.data)

--- a/src/eduid_common/api/tests/test_inputs.py
+++ b/src/eduid_common/api/tests/test_inputs.py
@@ -36,6 +36,7 @@ from flask import make_response
 
 from eduid_common.api.testing import EduidAPITestCase
 from eduid_common.api.session import SessionFactory
+from eduid_common.api.request import Request
 from eduid_userdb import UserDB
 
 
@@ -72,6 +73,7 @@ class InputsTests(EduidAPITestCase):
         app for this test case.
         """
         app = Flask('test.localhost')
+        app.request_class = Request
         app.config.update(config)
         app.register_blueprint(test_views)
         app.central_userdb = UserDB(app.config['MONGO_URI'], 'eduid_am')

--- a/src/eduid_common/api/tests/test_inputs.py
+++ b/src/eduid_common/api/tests/test_inputs.py
@@ -56,6 +56,15 @@ def get_param_view():
     return response
 
 
+@test_views.route('/test-post-param', methods=['POST'])
+def post_param_view():
+    param = request.form.get('test-param')
+    html = '<html><body>{}</body></html>'.format(param)
+    response = make_response(html, 200)
+    response.headers['Content-Type'] = "text/html; charset=utf8"
+    return response
+
+
 class InputsTests(EduidAPITestCase):
 
     def update_config(self, config):
@@ -92,6 +101,15 @@ class InputsTests(EduidAPITestCase):
         """"""
         url = '/test-get-param?test-param=<script>alert("ho")</script>'
         with self.app.test_request_context(url, method='GET'):
+
+            response = self.app.dispatch_request()
+            self.assertNotIn('<script>', response.data)
+
+    def test_post_param_script(self):
+        """"""
+        url = '/test-post-param'
+        with self.app.test_request_context(url, method='POST',
+                data={'test-param': '<script>alert("ho")</script>'}):
 
             response = self.app.dispatch_request()
             self.assertNotIn('<script>', response.data)

--- a/src/eduid_common/api/tests/test_inputs.py
+++ b/src/eduid_common/api/tests/test_inputs.py
@@ -30,6 +30,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+from werkzeug.http import dump_cookie
 from flask import Flask, Blueprint
 from flask import request
 from flask import make_response
@@ -60,6 +61,15 @@ def get_param_view():
 def post_param_view():
     param = request.form.get('test-param')
     html = '<html><body>{}</body></html>'.format(param)
+    response = make_response(html, 200)
+    response.headers['Content-Type'] = "text/html; charset=utf8"
+    return response
+
+
+@test_views.route('/test-cookie')
+def cookie_view():
+    cookie = request.cookies.get('test-cookie')
+    html = '<html><body>{}</body></html>'.format(cookie)
     response = make_response(html, 200)
     response.headers['Content-Type'] = "text/html; charset=utf8"
     return response
@@ -110,6 +120,17 @@ class InputsTests(EduidAPITestCase):
         url = '/test-post-param'
         with self.app.test_request_context(url, method='POST',
                 data={'test-param': '<script>alert("ho")</script>'}):
+
+            response = self.app.dispatch_request()
+            self.assertNotIn('<script>', response.data)
+
+    def test_post_param_script(self):
+        """"""
+        url = '/test-cookie'
+
+        cookie = dump_cookie('test-cookie', '<script>alert("ho")</script>')
+        with self.app.test_request_context(url, method='GET',
+                                           headers={'Cookie': cookie}):
 
             response = self.app.dispatch_request()
             self.assertNotIn('<script>', response.data)


### PR DESCRIPTION
Request class with user input sanitation.

 * Werkzeug's datastructures that hold user data in the request are extended to perform sanitation in their access methods.
 * New Request class using these datastructures
 * Our apps are configured to use this Request class, in eduid_common.api.app
 * Introducing a explicit dependency on flask (there were already quite a few imports from flask and werkzeug)