### PR TITLE
flexible webapp init

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-version = '0.2.2b2'
+version = '0.2.2b3'
 
 requires = [
     'setuptools >= 2.2',

--- a/src/eduid_common/api/app.py
+++ b/src/eduid_common/api/app.py
@@ -37,7 +37,7 @@ it with all attributes common to all eduID services.
 from eduid_userdb import UserDB
 from eduid_common.api.logging import init_logging
 from eduid_common.api.exceptions import init_exception_handlers, init_sentry
-from eduid_common.api.mailer import init_mailer
+from eduid_common.api.mail_relay import init_relay
 
 
 def etcd_config(name, app):
@@ -114,7 +114,7 @@ def eduid_init_app(name, config, cfg_func=etcd_config, app=True,
     app = init_logging(app)
     app = init_exception_handlers(app)
     app = init_sentry(app)
-    app = init_mailer(app)
+    app = init_relay(app)
     if sessions is True:
         from eduid_common.api.session import SessionFactory
         app.session_interface = SessionFactory(app.config)


### PR DESCRIPTION
Make the shared webapp init code flexible enough to be used by eduid-api.

I'm not entirely sure I think it was worth it, hence the request for review by all three of you.

/Fredrik
