### PR TITLE
python3 dislikes .get(None, default)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ version = '0.3.5b6'
 requires = [
     'six==1.11.0',
     'setuptools >= 2.2',
-    'eduid-userdb >= 0.3.2b4',
+    'eduid-userdb >= 0.4.0b13',
 ]
 
 # Flavours

--- a/src/eduid_common/config/parsers/ini.py
+++ b/src/eduid_common/config/parsers/ini.py
@@ -29,7 +29,8 @@ class IniConfigParser(object):
         :return: IniConfigParser object
         :rtype: IniConfigParser
         """
-
+        if config_environment_variable == None:
+            config_environment_variable = ''
         self.config_file_name = config_file_name
         self.config_environment_variable = config_environment_variable
         self.known_special_keys = {

--- a/src/eduid_common/config/parsers/ini.py
+++ b/src/eduid_common/config/parsers/ini.py
@@ -29,8 +29,6 @@ class IniConfigParser(object):
         :return: IniConfigParser object
         :rtype: IniConfigParser
         """
-        if config_environment_variable == None:
-            config_environment_variable = ''
         self.config_file_name = config_file_name
         self.config_environment_variable = config_environment_variable
         self.known_special_keys = {
@@ -47,10 +45,13 @@ class IniConfigParser(object):
         3. A file named .config_file_name in the user's home directory
         4. A file named config_file_name in the system configuration directory (/etc)
         """
-        file_name = os.environ.get(self.config_environment_variable, self.config_file_name)
+        if self.config_environment_variable:
+            env_file = os.environ.get(self.config_environment_variable, '')
+            if os.path.exists(env_file):
+                return env_file
 
-        if os.path.exists(file_name):
-            return file_name
+        if os.path.exists(self.config_file_name):
+            return self.config_file_name
 
         user_file = os.path.expanduser(
             os.path.join('~', '.', self.config_file_name))


### PR DESCRIPTION
python3 dislikes os.environ.get(None, default) - it wants a string rather than None