### PR TITLE
Eperez webauthn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-version = '0.3.8b5'
+version = '0.3.8b6'
 
 requires = [
     'six >= 1.11.0',

--- a/src/eduid_common/api/session.py
+++ b/src/eduid_common/api/session.py
@@ -163,8 +163,12 @@ class Session(collections.MutableMapping):
         """
         Store the session data in the redis backend,
         and renew the ttl for it.
+        
+        Check that session_id exists - when e.g. the account is being terminated,
+        the session has already been invalidated at this point.
         """
-        self._session.commit()
+        if self._session.session_id is not None:
+            self._session.commit()
 
     def renew_ttl(self, renew_backend):
         """


### PR DESCRIPTION
Check that session_id exists before saving the session to redis - when e.g. the account is being terminated, the session has already been invalidated at this point.