### PR TITLE
No longer accept empty user_is_logged_in

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-version = '0.3.8b7'
+version = '0.3.9'
 
 requires = [
     'six >= 1.11.0',

--- a/src/eduid_common/authn/middleware.py
+++ b/src/eduid_common/authn/middleware.py
@@ -62,8 +62,7 @@ class AuthnApp(Flask):
 
         with self.request_context(environ):
             try:
-                # TODO: Remove the 'is not False' when all live sessions have user_is_logged_in
-                if session.get('user_eppn') and session.get('user_is_logged_in') is not False:
+                if session.get('user_eppn') and session.get('user_is_logged_in'):
                     return super(AuthnApp, self).__call__(environ, start_response)
             except NoSessionDataFoundException:
                 current_app.logger.info('Caught a NoSessionDataFoundException - forcing the user to authenticate')


### PR DESCRIPTION
This means that we will invalidate all existing sessions for use in the
dashboard on deploy.