### PR TITLE
Changed from yaml.load() -> yaml.safe_load()

### DIFF
--- a/src/eduid_common/config/parsers/etcd.py
+++ b/src/eduid_common/config/parsers/etcd.py
@@ -162,7 +162,7 @@ class EtcdConfigParser(object):
         # thus might not need a yaml dependency
         import yaml
         with open(file_path) as f:
-            config = yaml.load(f)
+            config = yaml.safe_load(f)
             if not config:
                 raise ParserException('No YAML found in {!s}'.format(file_path))
             self.write_configuration(config)

--- a/src/eduid_common/config/scripts/etcd_config_bootstrap.py
+++ b/src/eduid_common/config/scripts/etcd_config_bootstrap.py
@@ -33,7 +33,7 @@ def load_yaml(file_path):
         with open(file_path) as f:
             if VERBOSE:
                 print('Loading configuration from {!s}'.format(file_path))
-            return yaml.load(f)
+            return yaml.safe_load(f)
     except IOError as e:
         sys.stderr.writelines(str(e)+'\n')
         sys.exit(1)


### PR DESCRIPTION
Although it is very unlikely that we'll receive untrusted yaml, it is best practice to use yaml.safe_load():
Example:
In [1]: import yaml
In [2]: v='!!python/object/apply:os.system ["uname -a"]'
In [3]: yaml.load(v)
Linux sangaku 4.19.0-0.bpo.2-amd64 #1 SMP Debian 4.19.16-1~bpo9+1 (2019-02-07) x86_64 GNU/Linux