### PR TITLE
Faster and less flaky tests

### DIFF
--- a/src/eduid_common/config/testing.py
+++ b/src/eduid_common/config/testing.py
@@ -97,3 +97,5 @@ class EtcdTemporaryInstance(object):
             self._process.terminate()
             self._process.wait()
             self._process = None
+        if EtcdTemporaryInstance._instance == self:
+            EtcdTemporaryInstance._instance = None

--- a/src/eduid_common/config/tests/test_etcd_parser.py
+++ b/src/eduid_common/config/tests/test_etcd_parser.py
@@ -17,6 +17,9 @@ __author__ = 'lundberg'
 class TestEtcdParser(unittest.TestCase):
 
     def setUp(self):
+        # FIXME: These tests can't be run on a shared etcd instance,
+        # because they expect a clean one, or else they fail from cross
+        # pollution of data.
         self.etcd_instance = EtcdTemporaryInstance()
 
         self.ns = '/test/'

--- a/src/eduid_common/config/tests/test_typed_config.py
+++ b/src/eduid_common/config/tests/test_typed_config.py
@@ -14,7 +14,7 @@ from eduid_common.config.base import FlaskConfig
 class TestTypedIdPConfig(unittest.TestCase):
 
     def setUp(self):
-        self.etcd_instance = EtcdTemporaryInstance()
+        self.etcd_instance = EtcdTemporaryInstance.get_instance()
 
         self.common_ns = '/eduid/webapp/common/'
         self.idp_ns = '/eduid/webapp/idp/'
@@ -47,9 +47,6 @@ class TestTypedIdPConfig(unittest.TestCase):
         os.environ['ETCD_HOST'] = self.etcd_instance.host
         os.environ['ETCD_PORT'] = str(self.etcd_instance.port)
 
-    def tearDown(self):
-        self.etcd_instance.shutdown()
-
     def test_default_setting(self):
         config = IdPConfig(app_name='idp')
         self.assertEqual(config.devel_mode, False)
@@ -72,7 +69,7 @@ class TestTypedIdPConfig(unittest.TestCase):
 class TestTypedFlaskConfig(unittest.TestCase):
 
     def setUp(self):
-        self.etcd_instance = EtcdTemporaryInstance()
+        self.etcd_instance = EtcdTemporaryInstance.get_instance()
 
         self.common_ns = '/eduid/webapp/common/'
         self.authn_ns = '/eduid/webapp/authn/'
@@ -106,9 +103,6 @@ class TestTypedFlaskConfig(unittest.TestCase):
         os.environ['EDUID_CONFIG_NS'] = '/eduid/webapp/authn/'
         os.environ['ETCD_HOST'] = self.etcd_instance.host
         os.environ['ETCD_PORT'] = str(self.etcd_instance.port)
-
-    def tearDown(self):
-        self.etcd_instance.shutdown()
 
     def test_base_default_setting(self):
         etcd_config = self.common_parser.read_configuration(silent=True)


### PR DESCRIPTION
This removes some flakyness from the tests, by resetting the class varable for the etcd instance if it ever gets shutdown during the tests. This can happen due to test ordering.

This also speeds some tests up by reusing a etcd instance between them, and possibly from previously run tests. As a note it documents which tests can't use this technique.

Local runs have the test time reduced from 70s to 48s by this.