### PR TITLE
wrong type for configuration key

### DIFF
--- a/src/eduid_common/config/base.py
+++ b/src/eduid_common/config/base.py
@@ -366,7 +366,7 @@ class FlaskConfig(BaseConfig):
     templates_auto_reload: Optional[bool] = None
     explain_template_loading: bool = False
     max_cookie_size: int = 4093
-    babel_translation_directories: List[str] = field(default_factory=list)
+    babel_translation_directories: str = 'translations'
     babel_default_locale: str = 'en'
     babel_default_timezone: str = ''
     babel_domain: str = ''


### PR DESCRIPTION
fixing the type of a configuration key.

'translations' is the default used by babel_flask