### PR TITLE
remove generated pasword salt from session

### DIFF
--- a/src/eduid_common/session/namespaces.py
+++ b/src/eduid_common/session/namespaces.py
@@ -79,7 +79,6 @@ class TimestampedNS(SessionNSBase):
 @dataclass
 class ResetPasswordNS(SessionNSBase):
     generated_password_hash: Optional[str] = None
-    generated_password_salt: Optional[str] = None
 
 
 @dataclass()


### PR DESCRIPTION
Remove space for the salt for the generated passwords in the session