### PR TITLE
Eperez resetpw namespace

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-version = '0.4.10'
+version = '0.4.11'
 
 requires = [
     'six >= 1.11.0',

--- a/src/eduid_common/authn/tests/test_fido_tokens.py
+++ b/src/eduid_common/authn/tests/test_fido_tokens.py
@@ -32,7 +32,6 @@
 #
 
 
-
 import json
 from dataclasses import dataclass, field
 from copy import deepcopy
@@ -61,7 +60,9 @@ class TestFidoConfig(FlaskConfig):
     u2f_valid_facets: list = field(default_factory=lambda: ['https://dashboard.dev.eduid.se',
                                                             'https://idp.dev.eduid.se'])
 
+
 views = Blueprint('testing', 'testing', url_prefix='')
+
 
 @views.route('/start', methods=["GET"])
 def start_verification():
@@ -71,9 +72,9 @@ def start_verification():
         result = verify_webauthn(user, data, 'testing')
     except VerificationProblem:
         result = {
-                'success': False,
-                'message': 'mfa.verification-problem'
-                }
+            'success': False,
+            'message': 'mfa.verification-problem'
+        }
     return json.dumps(result)
 
 
@@ -87,18 +88,29 @@ class TestFidoApp(EduIDBaseApp):
 
 
 SAMPLE_WEBAUTHN_REQUEST = {
-    #'authenticatorData': 'mZ9k6EPHoJxJZNA+UuvM0JVoutZHmqelg9kXe/DSefgBAAAA/w==',
     'authenticatorData': 'EqW1xI3n-hgnNPFAHqXwTnBqgKgUMmBLDxB7n3apMPQAAAAAAA',
-    'clientDataJSON': 'eyJjaGFsbGVuZ2UiOiIzaF9FQVpwWTI1eERkU0pDT014MUFCWkVBNU9k'+\
-                      'ejN5ZWpVSTNBVU5UUVdjIiwib3JpZ2luIjoiaHR0cHM6Ly9pZHAuZGV2'+\
-                      'LmVkdWlkLnNlIiwidHlwZSI6IndlYmF1dGhuLmdldCJ9',
-    'credentialId': 'i3KjBT0t5TPm693T9O0f4zyiwvdu9cY8BegCjiVvq_FS-ZmPcvXipFvHvD'+\
-                    '5CH6ZVRR3nsVsOla0Cad3fbtUA_Q',
-    'signature': 'MEYCIQC5gM8inamJGUFKu3bNo4fT0jmJQuw33OSSXc242NCuiwIhAIWnVw2Sp'+\
-                 'ow72j6J92KaY2rLR6qSXEbLam09ZXbSkBnQ'  # this is a fake
-                                                        # signature, we mock
-                                                        # its verification
-                                                        # below
+    'clientDataJSON': 'eyJjaGFsbGVuZ2UiOiIzaF9FQVpwWTI1eERkU0pDT014MUFCWkVBNU9kejN5ZWpVSTNBVU5UUVdjIiwib3JpZ2luIjoiaHR0cHM6Ly9pZHAuZGV2LmVkdWlkLnNlIiwidHlwZSI6IndlYmF1dGhuLmdldCJ9',
+    'credentialId': 'i3KjBT0t5TPm693T9O0f4zyiwvdu9cY8BegCjiVvq_FS-ZmPcvXipFvHvD5CH6ZVRR3nsVsOla0Cad3fbtUA_Q',
+    #  This is a fake signature, we mock its verification below
+    'signature': 'MEYCIQC5gM8inamJGUFKu3bNo4fT0jmJQuw33OSSXc242NCuiwIhAIWnVw2Spow72j6J92KaY2rLR6qSXEbLam09ZXbSkBnQ'
+}
+
+
+SAMPLE_WEBAUTHN_CREDENTIAL = {
+    'keyhandle': 'i3KjBT0t5TPm693T9O0f4zyiwvdu9cY8BegCjiVvq_FS-ZmPcvXipFvHvD5CH6ZVRR3nsVsOla0Cad3fbtUA_Q',
+    'credential_data': 'AAAAAAAAAAAAAAAAAAAAAABAi3KjBT0t5TPm693T9O0f4zyiwvdu9cY8BegCjiVvq_FS-ZmPcvXipFvHvD5CH6ZVRR3nsVsOla0Cad3fbtUA_aUBAgMmIAEhWCCiwDYGxl1LnRMqooWm0aRR9YbBG2LZ84BMNh_4rHkA9yJYIIujMrUOpGekbXjgMQ8M13ZsBD_cROSPB79eGz2Nw1ZE',
+    'app_id': '',
+    'attest_obj': 'bzJObWJYUmtibTl1WldkaGRIUlRkRzEwb0doaGRYUm9SR0YwWVZqRXhvVGI1OVBlcEV0YW9PYWY5RDlOUjIxVWJfSU5PT0tfVDdubDFuZHNIUlJCQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQVFJdHlvd1U5TGVVejV1dmQwX1R0SC1NOG9zTDNidlhHUEFYb0FvNGxiNnZ4VXZtWmozTDE0cVJieDd3LVFoLW1WVVVkNTdGYkRwV3RBbW5kMzI3VkFQMmxBUUlESmlBQklWZ2dvc0EyQnNaZFM1MFRLcUtGcHRHa1VmV0d3UnRpMmZPQVREWWYtS3g1QVBjaVdDQ0xveksxRHFSbnBHMTQ0REVQRE5kMmJBUV8zRVRrandlX1hoczlqY05XUkE=',
+    'description': 'unit test webauthn token',
+}
+
+SAMPLE_U2F_CREDENTIAL = {
+    'version': 'U2F_V2',
+    'keyhandle': 'V1vXqZcwBJD2RMIH2udd2F7R9NoSNlP7ZSPOtKHzS7n_rHFXcXbSpOoX__aUKyTR6jEC8Xv678WjXC5KEkvziA',
+    'public_key': 'BHVTWuo3_D7ruRBe2Tw-m2atT2IOm_qQWSDreWShu3t21ne9c-DPSUdym-H-t7FcjV7rj1dSc3WSwaOJpFmkKxQ',
+    'app_id': 'https://eduid.se/u2f-app-id.json',
+    'attest_cert': '',
+    'description': 'unit test U2F token'
 }
 
 
@@ -106,21 +118,8 @@ class FidoTokensTestCase(EduidAPITestCase):
 
     def setUp(self):
         super(FidoTokensTestCase, self).setUp()
-        self.webauthn_credential = Webauthn(
-                    keyhandle='i3KjBT0t5TPm693T9O0f4zyiwvdu9cY8BegCjiVvq_FS-ZmPcvXipFvHvD5CH6ZVRR3nsVsOla0Cad3fbtUA_Q',
-                    credential_data='AAAAAAAAAAAAAAAAAAAAAABAi3KjBT0t5TPm693T9O0f4zyiwvdu9cY8BegCjiVvq_FS-ZmPcvXipFvHvD5CH6ZVRR3nsVsOla0Cad3fbtUA_aUBAgMmIAEhWCCiwDYGxl1LnRMqooWm0aRR9YbBG2LZ84BMNh_4rHkA9yJYIIujMrUOpGekbXjgMQ8M13ZsBD_cROSPB79eGz2Nw1ZE',
-                    app_id='',
-                    attest_obj='bzJObWJYUmtibTl1WldkaGRIUlRkRzEwb0doaGRYUm9SR0YwWVZqRXhvVGI1OVBlcEV0YW9PYWY5RDlOUjIxVWJfSU5PT0tfVDdubDFuZHNIUlJCQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQVFJdHlvd1U5TGVVejV1dmQwX1R0SC1NOG9zTDNidlhHUEFYb0FvNGxiNnZ4VXZtWmozTDE0cVJieDd3LVFoLW1WVVVkNTdGYkRwV3RBbW5kMzI3VkFQMmxBUUlESmlBQklWZ2dvc0EyQnNaZFM1MFRLcUtGcHRHa1VmV0d3UnRpMmZPQVREWWYtS3g1QVBjaVdDQ0xveksxRHFSbnBHMTQ0REVQRE5kMmJBUV8zRVRrandlX1hoczlqY05XUkE=',
-                    description='unit test webauthn token',
-        )
-        self.u2f_credential = U2F(
-                  version='U2F_V2',
-                  keyhandle='V1vXqZcwBJD2RMIH2udd2F7R9NoSNlP7ZSPOtKHzS7n_rHFXcXbSpOoX__aUKyTR6jEC8Xv678WjXC5KEkvziA',
-                  public_key='BHVTWuo3_D7ruRBe2Tw-m2atT2IOm_qQWSDreWShu3t21ne9c-DPSUdym-H-t7FcjV7rj1dSc3WSwaOJpFmkKxQ',
-                  app_id='https://eduid.se/u2f-app-id.json',
-                  attest_cert='',
-                  description='unit test U2F token'
-                  )
+        self.webauthn_credential = Webauthn(**SAMPLE_WEBAUTHN_CREDENTIAL)
+        self.u2f_credential = U2F(**SAMPLE_U2F_CREDENTIAL)
 
     def load_app(self, config):
         """
@@ -131,7 +130,7 @@ class FidoTokensTestCase(EduidAPITestCase):
 
     def update_config(self, app_config):
         app_config.update({
-            'available_languages': {'en': 'English','sv': 'Svenska'},
+            'available_languages': {'en': 'English', 'sv': 'Svenska'},
             'celery_config': {
                 'result_backend': 'amqp',
                 'task_serializer': 'json',
@@ -139,7 +138,6 @@ class FidoTokensTestCase(EduidAPITestCase):
             },
         })
         return TestFidoConfig(**app_config)
-
 
     def test_u2f_start_verification(self):
         test_user = User(data=NEW_USER_EXAMPLE)
@@ -168,7 +166,6 @@ class FidoTokensTestCase(EduidAPITestCase):
                 with self.app.test_request_context():
                     config = start_token_verification(test_user, 'testing')
                     self.assertEqual(json.loads(config['u2fdata']), {})
-
 
     @patch('fido2.cose.ES256.verify')
     def test_webauthn_verify(self, mock_verify):

--- a/src/eduid_common/session/namespaces.py
+++ b/src/eduid_common/session/namespaces.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from abc import ABC, abstractmethod
+from abc import ABC
 from copy import deepcopy
 from datetime import datetime
 
@@ -79,11 +79,21 @@ class TimestampedNS(SessionNSBase):
 @dataclass
 class ResetPasswordNS(SessionNSBase):
     generated_password_hash: Optional[str] = None
+    resetpw_email_verification_code: Optional[str] = None
+    resetpw_sms_verification_code: Optional[str] = None
+    # XXX the keys below are not in use yet. They are set in eduid-common,
+    # in a way that the security app understands. Once the (reset|change)
+    # password views are removed from the security app, we will be able to
+    # start using them. The session key reauthn-for-chpass is in the same
+    # situation.
+    extrasec_u2f_challenge: Optional[str] = None
+    extrasec_webauthn_state: Optional[str] = None
 
 
 @dataclass()
 class Signup(TimestampedNS):
     """"""
+
 
 @dataclass()
 class Actions(TimestampedNS):


### PR DESCRIPTION
* Add a couple of keys to the reset-password session namespace
* Allow reuse of test webauthn and u2f credentials
* A bit of pep8 cleanup of the involved modules