### PR TITLE
Eperez signup key

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-version = '0.4.13'
+version = '0.4.14'
 
 requires = [
     'six >= 1.11.0',

--- a/src/eduid_common/session/namespaces.py
+++ b/src/eduid_common/session/namespaces.py
@@ -92,7 +92,7 @@ class ResetPasswordNS(SessionNSBase):
 
 @dataclass()
 class Signup(TimestampedNS):
-    """"""
+    email_verification_code: Optional[str] = None
 
 
 @dataclass()


### PR DESCRIPTION
Add a new key to the session for the signup app, that will hold the verification code when the backdoor to avoid its verification is in place