### PR TITLE
Eperez cleanup

### DIFF
--- a/src/eduid_common/api/app.py
+++ b/src/eduid_common/api/app.py
@@ -35,9 +35,8 @@ it with all attributes common to all eduID services.
 """
 import importlib.util
 import os
-import warnings
-from dataclasses import fields, asdict
-from typing import cast, Type, Optional, Mapping
+from dataclasses import asdict
+from typing import Type, Optional
 
 from eduid_userdb import UserDB
 from flask import Flask
@@ -49,7 +48,7 @@ from eduid_common.api.exceptions import init_exception_handlers, init_sentry
 from eduid_common.api.logging import init_logging
 from eduid_common.api.middleware import PrefixMiddleware
 from eduid_common.api.request import Request
-from eduid_common.api.utils import init_template_functions, urlappend
+from eduid_common.api.utils import init_template_functions
 from eduid_common.authn.utils import no_authn_views
 from eduid_common.config.base import FlaskConfig
 from eduid_common.config.exceptions import BadConfiguration

--- a/src/eduid_common/api/decorators.py
+++ b/src/eduid_common/api/decorators.py
@@ -10,9 +10,7 @@ from functools import wraps
 from flask import abort, current_app, request, jsonify
 from marshmallow.exceptions import ValidationError
 from eduid_common.session import session
-from eduid_userdb.exceptions import UserDoesNotExist, MultipleUsersReturned
 from eduid_common.api.utils import get_user
-from eduid_common.api.schemas.base import FluxStandardAction
 from eduid_common.api.schemas.models import FluxResponseStatus, FluxSuccessResponse, FluxFailResponse
 
 __author__ = 'lundberg'
@@ -209,7 +207,7 @@ def deprecated(reason):
 class Deprecated(object):
     """
     Mark deprecated functions with this decorator.
-    
+
     Attention! Use it as the closest one to the function you decorate.
 
     :param message: The deprecation message

--- a/src/eduid_common/api/helpers.py
+++ b/src/eduid_common/api/helpers.py
@@ -32,7 +32,7 @@ def set_user_names_from_offical_address(proofing_user, proofing_log_entry):
     # Only set display name if not already set
     if not proofing_user.display_name:
         if given_name_marking:
-            given_name_marking = int((int(given_name_marking)/10)-1)  # ex. "20" -> 1 (second given name)
+            given_name_marking = int((int(given_name_marking) / 10) - 1)  # ex. "20" -> 1 (second given name)
             proofing_user.display_name = u'{} {}'.format(name['GivenName'].split()[given_name_marking],
                                                          proofing_user.surname)
         else:

--- a/src/eduid_common/api/logging.py
+++ b/src/eduid_common/api/logging.py
@@ -1,5 +1,13 @@
 # -*- coding: utf-8 -*-
 
+# From https://stackoverflow.com/a/39757388
+# The TYPE_CHECKING constant is always False at runtime, so the import won't be evaluated, but mypy
+# (and other type-checking tools) will evaluate the contents of that block.
+from __future__ import annotations
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from eduid_common.api.app import EduIDBaseApp
+
 import logging
 import logging.config
 from os import environ
@@ -9,13 +17,6 @@ import time
 
 from eduid_common.config.exceptions import BadConfiguration
 from eduid_common.session import session
-
-# From https://stackoverflow.com/a/39757388
-# The TYPE_CHECKING constant is always False at runtime, so the import won't be evaluated, but mypy
-# (and other type-checking tools) will evaluate the contents of that block.
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    from eduid_common.api.app import EduIDBaseApp
 
 
 __author__ = 'lundberg'

--- a/src/eduid_common/api/logging.py
+++ b/src/eduid_common/api/logging.py
@@ -1,13 +1,5 @@
 # -*- coding: utf-8 -*-
 
-# From https://stackoverflow.com/a/39757388
-# The TYPE_CHECKING constant is always False at runtime, so the import won't be evaluated, but mypy
-# (and other type-checking tools) will evaluate the contents of that block.
-from __future__ import annotations
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    from eduid_common.api.app import EduIDBaseApp
-
 import logging
 import logging.config
 from os import environ
@@ -17,6 +9,13 @@ import time
 
 from eduid_common.config.exceptions import BadConfiguration
 from eduid_common.session import session
+
+# From https://stackoverflow.com/a/39757388
+# The TYPE_CHECKING constant is always False at runtime, so the import won't be evaluated, but mypy
+# (and other type-checking tools) will evaluate the contents of that block.
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from eduid_common.api.app import EduIDBaseApp
 
 
 __author__ = 'lundberg'

--- a/src/eduid_common/api/mail_relay.py
+++ b/src/eduid_common/api/mail_relay.py
@@ -30,8 +30,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-from copy import deepcopy
-
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from typing import List, Optional

--- a/src/eduid_common/api/msg.py
+++ b/src/eduid_common/api/msg.py
@@ -155,6 +155,3 @@ class MsgRelay(object):
         except Exception as e:
             rtask.forget()
             raise MsgTaskFailed(f'ping task failed: {repr(e)}')
-
-
-

--- a/src/eduid_common/api/request.py
+++ b/src/eduid_common/api/request.py
@@ -44,9 +44,6 @@ of the Flask application::
     >>> app = Flask('name')
     >>> app.request_class =  Request
 """
-import six
-from bleach import clean
-from six.moves.urllib_parse import unquote, quote
 
 from werkzeug._compat import iteritems, itervalues
 from werkzeug.utils import cached_property
@@ -55,7 +52,7 @@ from werkzeug.datastructures import ImmutableTypeConversionDict
 from werkzeug.datastructures import EnvironHeaders
 
 from flask import Request as BaseRequest
-from flask import abort, current_app, request
+from flask import abort, current_app
 
 from eduid_common.api.sanitation import Sanitizer, SanitationProblem
 
@@ -70,7 +67,7 @@ class SanitationMixin(Sanitizer):
         logger = current_app.logger
         try:
             return super(SanitationMixin, self).sanitize_input(untrusted_text, logger,
-                                                        strip_characters=strip_characters)
+                                                               strip_characters=strip_characters)
         except SanitationProblem:
             abort(400)
 
@@ -263,7 +260,7 @@ class Request(BaseRequest, SanitationMixin):
     """
     Request objects with sanitized inputs
     """
-    
+
     parameter_storage_class = SanitizedImmutableMultiDict
     dict_storage_class = SanitizedTypeConversionDict
 

--- a/src/eduid_common/api/sanitation.py
+++ b/src/eduid_common/api/sanitation.py
@@ -33,7 +33,7 @@ import six
 from bleach import clean
 from six.moves.urllib_parse import unquote, quote
 
-from flask import current_app, request
+from flask import request
 
 
 class SanitationProblem(Exception):
@@ -83,7 +83,7 @@ class Sanitizer(object):
 
         except UnicodeDecodeError:
             logger.warn('A malicious user tried to crash the application '
-                                    'by sending non-unicode input in a GET request')
+                        'by sending non-unicode input in a GET request')
             raise SanitationProblem('Non-unicode input')
 
     def _sanitize_input(self, untrusted_text, logger, strip_characters=False,
@@ -140,7 +140,7 @@ class Sanitizer(object):
 
             if decoded_text != cleaned_text:
                 logger.warn('Some potential harmful characters were '
-                                        'removed from untrusted user input.')
+                            'removed from untrusted user input.')
 
             if decoded_text != untrusted_text:
                 # Note that at least '&' and '=' needs to be unencoded when using PySAML2

--- a/src/eduid_common/api/schemas/csrf.py
+++ b/src/eduid_common/api/schemas/csrf.py
@@ -81,4 +81,3 @@ class CSRFResponse(FluxStandardAction):
         if not out_data.get('payload'):
             out_data['payload'] = {'csrf_token': None}
         return out_data
-

--- a/src/eduid_common/api/schemas/models.py
+++ b/src/eduid_common/api/schemas/models.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 
-from eduid_common.session import session
 from eduid_common.api.utils import get_flux_type
 
 __author__ = 'lundberg'

--- a/src/eduid_common/api/schemas/u2f.py
+++ b/src/eduid_common/api/schemas/u2f.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from marshmallow import Schema, fields
+from marshmallow import fields
 from eduid_common.api.schemas.base import EduidSchema
 
 __author__ = 'lundberg'

--- a/src/eduid_common/api/schemas/validators.py
+++ b/src/eduid_common/api/schemas/validators.py
@@ -1,16 +1,15 @@
 # -*- coding: utf-8 -*-
 
 import re
-from six import string_types
 from marshmallow import ValidationError
 
 __author__ = 'lundberg'
 
 nin_re = re.compile(r'^(18|19|20)\d{2}(0[1-9]|1[0-2])\d{2}\d{4}$')
 # RFC2822_email, http://www.regular-expressions.info/email.html
-email_re = re.compile("(?i)[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/="
-                      "?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\."
-                      ")+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?")
+email_re = re.compile(r"(?i)[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/="
+                      r"?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\."
+                      r")+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?")
 
 
 def validate_nin(nin):

--- a/src/eduid_common/api/testing.py
+++ b/src/eduid_common/api/testing.py
@@ -45,7 +45,6 @@ from flask.testing import FlaskClient
 from eduid_common.session.testing import RedisTemporaryInstance
 from eduid_common.api.testing_base import CommonTestCase
 from eduid_common.session import EduidSession
-from eduid_common.config.base import FlaskConfig
 from eduid_userdb import User
 from eduid_userdb.db import BaseDB
 from eduid_userdb.data_samples import (NEW_USER_EXAMPLE,
@@ -177,7 +176,7 @@ class EduidAPITestCase(CommonTestCase):
         except Exception as exc:
             sys.stderr.write("Exception in tearDown: {!s}\n{!r}\n".format(exc, exc))
             traceback.print_exc()
-            #time.sleep(5)
+            # time.sleep(5)
         super(CommonTestCase, self).tearDown()
         # XXX reset redis
 

--- a/src/eduid_common/api/testing_base.py
+++ b/src/eduid_common/api/testing_base.py
@@ -39,9 +39,7 @@ from typing import Optional, List, Dict, Any
 
 from eduid_common.config.testing import EtcdTemporaryInstance
 from eduid_common.config.workers import AmConfig
-from eduid_userdb import User
 from eduid_userdb.testing import MongoTestCase
-from eduid_userdb.data_samples import NEW_USER_EXAMPLE, NEW_UNVERIFIED_USER_EXAMPLE, NEW_COMPLETED_SIGNUP_USER_EXAMPLE
 
 logger = logging.getLogger(__name__)
 
@@ -62,13 +60,13 @@ class CommonTestCase(MongoTestCase):
 
         # setup AM
         celery_settings = {
-                'broker_transport': 'memory',
-                'broker_url': 'memory://',
-                'task_eager_propagates': True,
-                'task_always_eager': True,
-                'result_backend': 'cache',
-                'cache_backend': 'memory',
-                }
+            'broker_transport': 'memory',
+            'broker_url': 'memory://',
+            'task_eager_propagates': True,
+            'task_always_eager': True,
+            'result_backend': 'cache',
+            'cache_backend': 'memory',
+        }
         # Be sure to NOT tell AttributeManager about the temporary mongodb instance.
         # If we do, one or more plugins may open DB connections that never gets closed.
         mongo_uri = None

--- a/src/eduid_common/api/tests/test_inputs.py
+++ b/src/eduid_common/api/tests/test_inputs.py
@@ -57,6 +57,7 @@ __author__ = 'lundberg'
 def dont_validate(value):
     raise ValidationError('Problem with {!r}'.format(value))
 
+
 class NonValidatingSchema(EduidSchema, CSRFRequestMixin):
     test_data = fields.String(required=True, validate=dont_validate)
 
@@ -72,6 +73,7 @@ def _make_response(data):
     response = make_response(html, 200)
     response.headers['Content-Type'] = "text/html; charset=utf8"
     return response
+
 
 @test_views.route('/test-get-param', methods=['GET'])
 def get_param_view():
@@ -97,10 +99,12 @@ def cookie_view():
     cookie = request.cookies.get('test-cookie')
     return _make_response(cookie)
 
+
 @test_views.route('/test-empty-session')
 def empty_session_view():
     cookie = request.cookies.get('sessid')
     return _make_response(cookie)
+
 
 @test_views.route('/test-header')
 def header_view():
@@ -184,7 +188,7 @@ class InputsTests(EduidAPITestCase):
         """"""
         url = '/test-post-param'
         with self.app.test_request_context(url, method='POST',
-                data={'test-param': '<script>alert("ho")</script>'}):
+                                           data={'test-param': '<script>alert("ho")</script>'}):
 
             response = self.app.dispatch_request()
             self.assertNotIn(b'<script>', response.data)
@@ -192,7 +196,7 @@ class InputsTests(EduidAPITestCase):
     def test_post_param_script_percent_encoded(self):
         url = '/test-post-param'
         with self.app.test_request_context(url, method='POST',
-                data={'test-param': '%3Cscript%3Ealert%28%22ho%22%29%3C%2Fscript%3E'}):
+                                           data={'test-param': '%3Cscript%3Ealert%28%22ho%22%29%3C%2Fscript%3E'}):
 
             response = self.app.dispatch_request()
             self.assertNotIn(b'<script>', response.data)
@@ -200,7 +204,7 @@ class InputsTests(EduidAPITestCase):
     def test_post_param_script_percent_encoded_twice(self):
         url = '/test-post-param'
         with self.app.test_request_context(url, method='POST',
-                data={'test-param': b'%253Cscript%253Ealert%2528%2522ho%2522%2529%253C%252Fscript%253E'}):
+                                           data={'test-param': b'%253Cscript%253Ealert%2528%2522ho%2522%2529%253C%252Fscript%253E'}):
 
             response = self.app.dispatch_request()
             unquoted_response = unquote(response.data.decode('ascii'))
@@ -211,13 +215,13 @@ class InputsTests(EduidAPITestCase):
         """"""
         url = '/test-post-json'
         with self.app.test_request_context(url, method='POST',
-                content_type='application/json',
-                headers={
-                    "X-Requested-With": "XMLHttpRequest",
-                    "Host": "test.localhost",
-                    "Origin": "http://test.localhost",
-                },
-                data='{"test_data": "<script>alert(42)</script>", "csrf_token": "failing-token"}'):
+                                           content_type='application/json',
+                                           headers={
+                                               "X-Requested-With": "XMLHttpRequest",
+                                               "Host": "test.localhost",
+                                               "Origin": "http://test.localhost",
+                                           },
+                                           data='{"test_data": "<script>alert(42)</script>", "csrf_token": "failing-token"}'):
 
             response = self.app.dispatch_request()
             self.assertNotIn(b'<script>', response.data)
@@ -254,7 +258,7 @@ class InputsTests(EduidAPITestCase):
         """"""
         url = '/test-values'
         with self.app.test_request_context(url, method='POST',
-                data={'test-param': '<script>alert("ho")</script>'}):
+                                           data={'test-param': '<script>alert("ho")</script>'}):
 
             response = self.app.dispatch_request()
             self.assertNotIn(b'<script>', response.data)

--- a/src/eduid_common/api/utils.py
+++ b/src/eduid_common/api/utils.py
@@ -40,7 +40,7 @@ def update_modified_ts(user):
         current_app.logger.debug("User {!s} has no id, setting modified_ts to None".format(user))
         user.modified_ts = None
         return
-    
+
     private_user = current_app.private_userdb.get_user_by_id(userid, raise_on_missing=False)
     if private_user is None:
         current_app.logger.debug("User {!s} not found in {!s}, "

--- a/src/eduid_common/authn/assurance.py
+++ b/src/eduid_common/authn/assurance.py
@@ -152,10 +152,10 @@ def response_authn(req_authn_ctx: Optional[str], user: IdPUser, sso_session, log
     authn = AuthnState(user, sso_session, logger)
     logger.info(f'Authn for {user} will be evaluated based on: {authn}')
 
-    cc = {'REFEDS_MFA':  'https://refeds.org/profile/mfa',
-          'REFEDS_SFA':  'https://refeds.org/profile/sfa',
-          'FIDO_U2F':    'https://www.swamid.se/specs/id-fido-u2f-ce-transports',
-          'EDUID_MFA':   'https://eduid.se/specs/mfa',
+    cc = {'REFEDS_MFA': 'https://refeds.org/profile/mfa',
+          'REFEDS_SFA': 'https://refeds.org/profile/sfa',
+          'FIDO_U2F': 'https://www.swamid.se/specs/id-fido-u2f-ce-transports',
+          'EDUID_MFA': 'https://eduid.se/specs/mfa',
           'PASSWORD_PT': 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
           }
 

--- a/src/eduid_common/authn/eduid_saml2.py
+++ b/src/eduid_common/authn/eduid_saml2.py
@@ -185,7 +185,7 @@ def authenticate(app, session_info):
 
     saml_user = attribute_values[0]
 
-    # eduPersonPrincipalName might be scoped and the scope (e.g. "@example.com") 
+    # eduPersonPrincipalName might be scoped and the scope (e.g. "@example.com")
     # might have to be removed before looking for the user in the database.
     strip_suffix = app.config.get('SAML2_STRIP_SAML_USER_SUFFIX', '')
     if strip_suffix:

--- a/src/eduid_common/authn/fido_tokens.py
+++ b/src/eduid_common/authn/fido_tokens.py
@@ -198,9 +198,10 @@ def verify_webauthn(user, request_dict: dict, session_prefix: str) -> dict:
         try:
             request_dict[this] += ('=' * (len(request_dict[this]) % 4))
             req[this] = base64.urlsafe_b64decode(request_dict[this])
-        except:
+        except Exception as exc:
             current_app.logger.error(f'Failed to find/b64decode Webauthn '
-                                     f'parameter {this}: {request_dict.get(this)}')
+                                     f'parameter {this}: {request_dict.get(this)}'
+                                     f'and the exception is {exc}')
             raise VerificationProblem('mfa.bad-token-response')  # XXX add bad-token-response to frontend
 
     current_app.logger.debug(f'Webauthn request after decoding:\n{pprint.pformat(req)}')

--- a/src/eduid_common/authn/idp_authn.py
+++ b/src/eduid_common/authn/idp_authn.py
@@ -55,6 +55,7 @@ class AuthnData(object):
 
     Returned from functions performing authentication.
     """
+
     def __init__(self, user, credential, timestamp):
         self.user = user
         self.credential = credential
@@ -78,7 +79,7 @@ class AuthnData(object):
     def credential(self, value: Credential):
         # isinstance is broken here with Python2:
         #   ValueError: Invalid/unknown credential (got <class 'eduid_userdb.u2f.U2F'>)
-        #if not isinstance(value, Password) or isinstance(value, U2F):
+        # if not isinstance(value, Password) or isinstance(value, U2F):
         if not hasattr(value, 'key'):
             raise ValueError('Invalid/unknown credential (got {})'.format(type(value)))
         self._credential = value

--- a/src/eduid_common/authn/idp_saml.py
+++ b/src/eduid_common/authn/idp_saml.py
@@ -73,7 +73,7 @@ class IdP_SAMLRequest(object):
 
     @property
     def binding(self):
-         return self._binding
+        return self._binding
 
     def verify_signature(self, sig_alg: str, signature: str) -> bool:
         info = {'SigAlg': sig_alg,

--- a/src/eduid_common/authn/middleware.py
+++ b/src/eduid_common/authn/middleware.py
@@ -32,8 +32,7 @@
 
 import logging
 import re
-import warnings
-from typing import cast, Callable, Union
+from typing import Callable, Union
 
 from flask import current_app
 from urllib.parse import urlparse, urlunparse, urlencode, parse_qs

--- a/src/eduid_common/authn/tests/responses.py
+++ b/src/eduid_common/authn/tests/responses.py
@@ -24,7 +24,6 @@ def auth_response(session_id, uid):
 
     sp_baseurl = 'http://test.localhost:6544/'
 
-
     saml_response_tpl = """<?xml version='1.0' encoding='UTF-8'?>
 <samlp:Response xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
                 xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"

--- a/src/eduid_common/authn/tests/test_cache.py
+++ b/src/eduid_common/authn/tests/test_cache.py
@@ -31,7 +31,7 @@
 #
 import unittest
 
-from eduid_common.authn.cache import SessionCacheAdapter, OutstandingQueriesCache, IdentityCache, StateCache
+from eduid_common.authn.cache import SessionCacheAdapter, OutstandingQueriesCache, IdentityCache
 
 
 class SessionCacheAdapterTests(unittest.TestCase):

--- a/src/eduid_common/authn/tests/test_middleware.py
+++ b/src/eduid_common/authn/tests/test_middleware.py
@@ -50,7 +50,7 @@ class AuthnTests(EduidAPITestCase):
 
     def update_config(self, config):
         config.update({
-            'available_languages': {'en': 'English','sv': 'Svenska'},
+            'available_languages': {'en': 'English', 'sv': 'Svenska'},
             'development': 'DEBUG',
             'application_root': '/',
             'no_authn_urls': [],

--- a/src/eduid_common/authn/tests/test_vccs.py
+++ b/src/eduid_common/authn/tests/test_vccs.py
@@ -57,21 +57,21 @@ class VCCSTestCase(MongoTestCase):
         return vccs_module.check_password('dummy', creds, self.user, self.vccs_client)
 
     def test_check_good_credentials(self):
-        result = self._check_credentials('abcd') 
+        result = self._check_credentials('abcd')
         self.assertTrue(result)
 
     def test_check_bad_credentials(self):
-        result = self._check_credentials('fghi') 
+        result = self._check_credentials('fghi')
         self.assertFalse(result)
 
     def test_add_password(self):
         added = vccs_module.add_password(self.user, new_password='wxyz', application='test', vccs=self.vccs_client)
         self.assertTrue(added)
-        result1 = self._check_credentials('abcd') 
+        result1 = self._check_credentials('abcd')
         self.assertTrue(result1)
-        result2 = self._check_credentials('fghi') 
+        result2 = self._check_credentials('fghi')
         self.assertFalse(result2)
-        result3 = self._check_credentials('wxyz') 
+        result3 = self._check_credentials('wxyz')
         self.assertTrue(result3)
         self.assertFalse(result3.is_generated)
 
@@ -79,11 +79,11 @@ class VCCSTestCase(MongoTestCase):
         added = vccs_module.add_password(self.user, new_password='wxyz', is_generated=True,
                                          application='test', vccs=self.vccs_client)
         self.assertTrue(added)
-        result1 = self._check_credentials('abcd') 
+        result1 = self._check_credentials('abcd')
         self.assertTrue(result1)
-        result2 = self._check_credentials('fghi') 
+        result2 = self._check_credentials('fghi')
         self.assertFalse(result2)
-        result3 = self._check_credentials('wxyz') 
+        result3 = self._check_credentials('wxyz')
         self.assertTrue(result3)
         self.assertTrue(result3.is_generated)
 
@@ -91,11 +91,11 @@ class VCCSTestCase(MongoTestCase):
         added = vccs_module.change_password(self.user, new_password='wxyz', old_password='abcd', application='test',
                                             vccs=self.vccs_client)
         self.assertTrue(added)
-        result1 = self._check_credentials('abcd') 
+        result1 = self._check_credentials('abcd')
         self.assertFalse(result1)
-        result2 = self._check_credentials('fghi') 
+        result2 = self._check_credentials('fghi')
         self.assertFalse(result2)
-        result3 = self._check_credentials('wxyz') 
+        result3 = self._check_credentials('wxyz')
         self.assertTrue(result3)
         self.assertFalse(result3.is_generated)
 
@@ -104,11 +104,11 @@ class VCCSTestCase(MongoTestCase):
                                             application='test', is_generated=True,
                                             vccs=self.vccs_client)
         self.assertTrue(added)
-        result1 = self._check_credentials('abcd') 
+        result1 = self._check_credentials('abcd')
         self.assertFalse(result1)
-        result2 = self._check_credentials('fghi') 
+        result2 = self._check_credentials('fghi')
         self.assertFalse(result2)
-        result3 = self._check_credentials('wxyz') 
+        result3 = self._check_credentials('wxyz')
         self.assertTrue(result3)
         self.assertTrue(result3.is_generated)
 
@@ -116,11 +116,11 @@ class VCCSTestCase(MongoTestCase):
         added = vccs_module.change_password(self.user, new_password='wxyz', old_password='fghi', application='test',
                                             vccs=self.vccs_client)
         self.assertFalse(added)
-        result1 = self._check_credentials('abcd') 
+        result1 = self._check_credentials('abcd')
         self.assertTrue(result1)
-        result2 = self._check_credentials('fghi') 
+        result2 = self._check_credentials('fghi')
         self.assertFalse(result2)
-        result3 = self._check_credentials('wxyz') 
+        result3 = self._check_credentials('wxyz')
         self.assertFalse(result3)
 
     def test_reset_password(self):
@@ -153,11 +153,11 @@ class VCCSTestCase(MongoTestCase):
             added = vccs_module.change_password(self.user, new_password='wxyz', old_password='abcd', application='test',
                                                 vccs=self.vccs_client)
             self.assertFalse(added)
-            result1 = self._check_credentials('abcd') 
+            result1 = self._check_credentials('abcd')
             self.assertTrue(result1)
-            result2 = self._check_credentials('fghi') 
+            result2 = self._check_credentials('fghi')
             self.assertFalse(result2)
-            result3 = self._check_credentials('wxyz') 
+            result3 = self._check_credentials('wxyz')
             self.assertFalse(result3)
 
     def test_reset_password_error_revoking(self):
@@ -171,9 +171,9 @@ class VCCSTestCase(MongoTestCase):
             added = vccs_module.reset_password(self.user, new_password='wxyz', application='test',
                                                vccs=self.vccs_client)
             self.assertTrue(added)
-            result1 = self._check_credentials('abcd') 
+            result1 = self._check_credentials('abcd')
             self.assertFalse(result1)
-            result2 = self._check_credentials('fghi') 
+            result2 = self._check_credentials('fghi')
             self.assertFalse(result2)
-            result3 = self._check_credentials('wxyz') 
+            result3 = self._check_credentials('wxyz')
             self.assertTrue(result3)

--- a/src/eduid_common/authn/utils.py
+++ b/src/eduid_common/authn/utils.py
@@ -88,7 +88,7 @@ def get_saml_attribute(session_info, attr_name):
     :type attr_name: string()
     :rtype: [string()]
     """
-    if not 'ava' in session_info:
+    if 'ava' not in session_info:
         raise ValueError('SAML attributes (ava) not found in session_info')
 
     attributes = session_info['ava']

--- a/src/eduid_common/authn/vccs.py
+++ b/src/eduid_common/authn/vccs.py
@@ -85,7 +85,7 @@ def check_password(vccs_url, password, user, vccs=None):
             password,
             credential_id=str(user_password.key),
             salt=user_password.salt,
-            )
+        )
         try:
             if vccs.authenticate(str(user.user_id), [factor]):
                 return user_password
@@ -268,12 +268,12 @@ def add_credentials(vccs_url, old_password, new_password, user, source='dashboar
     if user.credentials.filter(Password).count > 0 and old_password_supplied:
         # Find the old credential to revoke
         checked_password = check_password(vccs_url, old_password, user, vccs=vccs)
-        del old_password # don't need it anymore, try to forget it
+        del old_password  # don't need it anymore, try to forget it
         if not checked_password:
             return False
         old_factor = vccs_client.VCCSRevokeFactor(str(checked_password.credential_id), 'changing password',
                                                   reference=source,
-        )
+                                                  )
 
     if not vccs.add_credentials(str(user.user_id), [new_factor]):
         logger.warning("Failed adding password credential {!r} for user {!r}".format(new_factor.credential_id, user))
@@ -295,8 +295,7 @@ def add_credentials(vccs_url, old_password, new_password, user, source='dashboar
                                                         'reset password',
                                                         reference=source))
             logger.debug("Revoking old credential (password reset) "
-                         "{!s} (user {!s})".format(
-                          password.credential_id, user))
+                         "{!s} (user {!s})".format(password.credential_id, user))
             user.credentials.remove(password.credential_id)
         if revoked:
             try:

--- a/src/eduid_common/config/base.py
+++ b/src/eduid_common/config/base.py
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class CeleryConfig:
     """
-    Celery configuration 
+    Celery configuration
     """
     accept_content: List[str] = field(default_factory=lambda: ["application/json"])
     broker_url: str = ''
@@ -61,9 +61,9 @@ class CeleryConfig:
     broker_transport: str = ''
     broker_transport_options: dict = field(default_factory=lambda: {"fanout_prefix": True})
     task_routes: dict = field(default_factory=lambda: {
-      'eduid_am.*': {'queue': 'am'},
-      'eduid_msg.*': {'queue': 'msg'},
-      'eduid_letter_proofing.*': {'queue': 'letter_proofing'}})
+        'eduid_am.*': {'queue': 'am'},
+        'eduid_msg.*': {'queue': 'msg'},
+        'eduid_letter_proofing.*': {'queue': 'letter_proofing'}})
     mongo_uri: Optional[str] = None
 
 
@@ -158,14 +158,14 @@ class CommonConfig:
         get a dict with the default values for all configuration keys
         """
         return {key: val for key, val in cls.__dict__.items()
-                  if isinstance(key, str) and not key.startswith('_') and not callable(val)}
+                if isinstance(key, str) and not key.startswith('_') and not callable(val)}
 
     def to_dict(self) -> dict:
         """
         get a dict with all configured values
         """
         return {key: val for key, val in self.__dict__.items()
-                  if isinstance(key, str) and not key.startswith('_') and not callable(val)}
+                if isinstance(key, str) and not key.startswith('_') and not callable(val)}
 
 
 @dataclass
@@ -195,8 +195,8 @@ class BaseConfig(CommonConfig):
     log_max_bytes: int = 1000000  # 1 MB
     log_backup_count: int = 10  # 10 x 1 MB
     log_format: str = '%(asctime)s | %(levelname)s | %(hostname)s | %(name)s | %(module)s | %(eppn)s | %(message)s'
-    log_type: List[str] = field(default_factory=lambda:['stream'])
-    logger : Optional[logging.Logger] = None
+    log_type: List[str] = field(default_factory=lambda: ['stream'])
+    logger: Optional[logging.Logger] = None
     # Redis config
     # The Redis host to use for session storage.
     redis_host: Optional[str] = None
@@ -227,11 +227,11 @@ class BaseConfig(CommonConfig):
     available_languages: Dict[str, str] = field(default_factory=lambda: {
         'en': 'English',
         'sv': 'Svenska'
-        })
+    })
     supported_languages: Dict[str, str] = field(default_factory=lambda: {
         'en': 'English',
         'sv': 'Svenska'
-        })
+    })
     mail_default_from: str = 'no-reply@eduid.se'
     static_url: str = ''
     dashboard_url: str = ''
@@ -255,12 +255,12 @@ class BaseConfig(CommonConfig):
     no_authn_urls: list = field(default_factory=lambda: [
         "^/status/healthy$",
         "^/status/sanity-check$"
-        ])
+    ])
     # The plugins for pre-authentication actions that need to be loaded
     action_plugins: list = field(default_factory=lambda: [
         "tou",
         "mfa"
-        ])
+    ])
     # The current version of the terms of use agreement.
     tou_version: str = '2017-v6'
     current_tou_version: str = '2017-v6'  # backwards compat
@@ -278,8 +278,8 @@ class BaseConfig(CommonConfig):
         Initialize configuration with values from etcd (or with test values)
         """
         config: Dict[str, Any] = {
-                'debug': debug,
-                }
+            'debug': debug,
+        }
         if test_config:
             # Load init time settings
             config.update(test_config)
@@ -317,7 +317,7 @@ class FlaskConfig(BaseConfig):
     # What environment the app is running in.
     # This is set by the FLASK_ENV environment variable and may not
     # behave as expected if set in code
-    env : str = 'production'
+    env: str = 'production'
     testing: bool = False
     # explicitly enable or disable the propagation of exceptions.
     # If not set or explicitly set to None this is implicitly true if either

--- a/src/eduid_common/config/idp.py
+++ b/src/eduid_common/config/idp.py
@@ -35,9 +35,7 @@ Configuration (file) handling for eduID IdP.
 """
 
 from dataclasses import dataclass, field
-import os
-from importlib import import_module
-from typing import Optional, List, Tuple, Dict, Any
+from typing import Optional, List, Tuple
 
 from .base import BaseConfig
 
@@ -114,7 +112,7 @@ class IdPConfig(BaseConfig):
     verify_request_signatures: bool = False
     # Get list of usernames valid for use with the /status URL.
     # If this list is ['*'], all usernames are allowed for /status.
-    status_test_usernames: List[str] =  field(default_factory=list)
+    status_test_usernames: List[str] = field(default_factory=list)
     # URL (string) for use in simple templating of login.html.
     signup_link: str = '#'
     # URL (string) for use in simple templating of forbidden.html.

--- a/src/eduid_common/config/parsers/__init__.py
+++ b/src/eduid_common/config/parsers/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
-
 from eduid_common.config.parsers.base import ConfigParser
 
 __author__ = 'lundberg'

--- a/src/eduid_common/config/parsers/decorators.py
+++ b/src/eduid_common/config/parsers/decorators.py
@@ -129,7 +129,7 @@ def interpolate_config(config_dict: dict, sub_dict: Optional[dict] = None) -> di
         sub_dict = config_dict
     # XXX case insensitive substitution - transitioning to lc config
     ci_config_dict = {}
-    for k,v in config_dict.items():
+    for k, v in config_dict.items():
         ci_config_dict[k] = v
         ci_config_dict[k.upper()] = v
     for key, value in sub_dict.items():

--- a/src/eduid_common/config/scripts/etcd_config_bootstrap.py
+++ b/src/eduid_common/config/scripts/etcd_config_bootstrap.py
@@ -35,7 +35,7 @@ def load_yaml(file_path):
                 print('Loading configuration from {!s}'.format(file_path))
             return yaml.safe_load(f)
     except IOError as e:
-        sys.stderr.writelines(str(e)+'\n')
+        sys.stderr.writelines(str(e) + '\n')
         sys.exit(1)
 
 

--- a/src/eduid_common/config/tests/test_etcd_parser.py
+++ b/src/eduid_common/config/tests/test_etcd_parser.py
@@ -2,7 +2,6 @@
 
 from __future__ import absolute_import
 
-import six
 import unittest
 from mock import patch
 from nacl import secret, encoding
@@ -60,11 +59,11 @@ class TestEtcdParser(unittest.TestCase):
             }
         }
         test_key = {
-                'my_bool': True,
-                'my_string': 'A value',
-                'my_list': ['One', 'Two', 3],
-                'my_dict': {'A': 'B'}
-            }
+            'my_bool': True,
+            'my_string': 'A value',
+            'my_list': ['One', 'Two', 3],
+            'my_dict': {'A': 'B'}
+        }
 
         self.parser.write_configuration(config)
         read_config = self.parser.read_configuration()
@@ -97,7 +96,7 @@ class TestEtcdParser(unittest.TestCase):
 
     @patch('eduid_common.config.parsers.decorators.read_secret_key')
     def test_decrypt(self, mock_read_secret_key):
-        mock_read_secret_key.return_value = bytes(b'A'*secret.SecretBox.KEY_SIZE)
+        mock_read_secret_key.return_value = bytes(b'A' * secret.SecretBox.KEY_SIZE)
 
         box = secret.SecretBox(decorators.read_secret_key('test'))
 
@@ -114,7 +113,7 @@ class TestEtcdParser(unittest.TestCase):
 
     @patch('eduid_common.config.parsers.decorators.read_secret_key')
     def test_decrypt_non_ascii(self, mock_read_secret_key):
-        mock_read_secret_key.return_value = bytes(b'A'*secret.SecretBox.KEY_SIZE)
+        mock_read_secret_key.return_value = bytes(b'A' * secret.SecretBox.KEY_SIZE)
 
         box = secret.SecretBox(decorators.read_secret_key('test'))
 
@@ -135,10 +134,10 @@ class TestEtcdParser(unittest.TestCase):
     @patch('eduid_common.config.parsers.decorators.read_secret_key')
     def test_decrypt_multi_key(self, mock_read_secret_key):
 
-        mock_read_secret_key.return_value = bytes(b'A'*secret.SecretBox.KEY_SIZE)
+        mock_read_secret_key.return_value = bytes(b'A' * secret.SecretBox.KEY_SIZE)
 
         box = secret.SecretBox(decorators.read_secret_key('test'))
-        box2 = secret.SecretBox(bytes(b'B'*secret.SecretBox.KEY_SIZE))
+        box2 = secret.SecretBox(bytes(b'B' * secret.SecretBox.KEY_SIZE))
 
         secret_value = [{
             'key_name': 'not_test',
@@ -245,7 +244,7 @@ class TestEtcdParser(unittest.TestCase):
 
     @patch('eduid_common.config.parsers.decorators.read_secret_key')
     def test_decrypt_interpolate(self, mock_read_secret_key):
-        mock_read_secret_key.return_value = bytes(b'A'*secret.SecretBox.KEY_SIZE)
+        mock_read_secret_key.return_value = bytes(b'A' * secret.SecretBox.KEY_SIZE)
 
         box = secret.SecretBox(decorators.read_secret_key('test'))
 

--- a/src/eduid_common/config/tests/test_idp_config.py
+++ b/src/eduid_common/config/tests/test_idp_config.py
@@ -37,18 +37,16 @@
 Test config parsing.
 """
 
-import os
 import unittest
-import pkg_resources
 
 from eduid_common.config.idp import IdPConfig
 
 
 TEST_CONFIG = {
-        'listen_port': 8000,
-        'static_dir': '/home/ft/work/NORDUnet/eduid-IdP/static/',
-        'vccs_url': 'dummy'
-        }
+    'listen_port': 8000,
+    'static_dir': '/home/ft/work/NORDUnet/eduid-IdP/static/',
+    'vccs_url': 'dummy'
+}
 
 
 class TestCredStore(unittest.TestCase):

--- a/src/eduid_common/rpc/worker.py
+++ b/src/eduid_common/rpc/worker.py
@@ -3,12 +3,11 @@
 from __future__ import absolute_import
 
 import os
-from typing import Type, Dict, Any, cast
+from typing import Type, Dict, Any
 
 from eduid_common.config.exceptions import BadConfiguration
 from eduid_common.config.parsers.etcd import EtcdConfigParser
 from eduid_common.config.base import CommonConfig, BaseConfig
-from eduid_common.config.workers import AmConfig, MsgConfig, MobConfig
 
 
 def get_worker_config(name: str, config_class: Type[CommonConfig] = BaseConfig) -> CommonConfig:

--- a/src/eduid_common/session/__init__.py
+++ b/src/eduid_common/session/__init__.py
@@ -32,8 +32,7 @@
 #
 
 from flask import session as flask_session
-from eduid_common.session.eduid_session import EduidSession, SessionManager
-from eduid_common.session.redis_session import RedisEncryptedSession
+from eduid_common.session.eduid_session import EduidSession
 
 
 # Ugly hack to get make type checks/hints to work

--- a/src/eduid_common/session/eduid_session.py
+++ b/src/eduid_common/session/eduid_session.py
@@ -1,12 +1,4 @@
 
-# From https://stackoverflow.com/a/39757388
-# The TYPE_CHECKING constant is always False at runtime, so the import won't be evaluated, but mypy
-# (and other type-checking tools) will evaluate the contents of that block.
-from __future__ import annotations
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    from eduid_common.api.app import EduIDBaseApp
-
 import os
 import binascii
 import json
@@ -24,6 +16,13 @@ from eduid_common.session.namespaces import SessionNSBase, Common, MfaAction
 from eduid_common.session.namespaces import Signup, Actions
 from eduid_common.session.namespaces import ResetPasswordNS
 from eduid_common.session.logindata import SSOLoginData
+
+# From https://stackoverflow.com/a/39757388
+# The TYPE_CHECKING constant is always False at runtime, so the import won't be evaluated, but mypy
+# (and other type-checking tools) will evaluate the contents of that block.
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from eduid_common.api.app import EduIDBaseApp
 
 
 class EduidSession(SessionMixin, MutableMapping):

--- a/src/eduid_common/session/eduid_session.py
+++ b/src/eduid_common/session/eduid_session.py
@@ -1,4 +1,12 @@
 
+# From https://stackoverflow.com/a/39757388
+# The TYPE_CHECKING constant is always False at runtime, so the import won't be evaluated, but mypy
+# (and other type-checking tools) will evaluate the contents of that block.
+from __future__ import annotations
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from eduid_common.api.app import EduIDBaseApp
+
 import os
 import binascii
 import json
@@ -16,13 +24,6 @@ from eduid_common.session.namespaces import SessionNSBase, Common, MfaAction
 from eduid_common.session.namespaces import Signup, Actions
 from eduid_common.session.namespaces import ResetPasswordNS
 from eduid_common.session.logindata import SSOLoginData
-
-# From https://stackoverflow.com/a/39757388
-# The TYPE_CHECKING constant is always False at runtime, so the import won't be evaluated, but mypy
-# (and other type-checking tools) will evaluate the contents of that block.
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    from eduid_common.api.app import EduIDBaseApp
 
 
 class EduidSession(SessionMixin, MutableMapping):

--- a/src/eduid_common/session/logindata.py
+++ b/src/eduid_common/session/logindata.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import pprint
 from datetime import datetime
-from html import escape, unescape
+from html import escape
 from dataclasses import dataclass, field, asdict
 from typing import Dict, Optional, Mapping, Type
 from urllib.parse import urlencode

--- a/src/eduid_common/session/sso_cache.py
+++ b/src/eduid_common/session/sso_cache.py
@@ -16,7 +16,7 @@ import uuid
 from abc import ABC
 from collections import deque
 from threading import Lock
-from typing import Any, Deque, Dict, List, Mapping, NewType, Optional, Union, overload, cast, Tuple
+from typing import Any, Deque, Dict, List, Mapping, NewType, Optional, Union, cast, Tuple
 
 from eduid_userdb import MongoDB
 
@@ -24,8 +24,6 @@ _SHA1_HEXENCODED_SIZE = 160 // 8 * 2
 
 # A distinct type for session ids
 SSOSessionId = NewType('SSOSessionId', bytes)
-
-
 
 
 class NoOpLock(object):
@@ -236,7 +234,6 @@ class SSOSessionCache(ABC):
         return SSOSessionId(str(uuid.uuid4()).encode('utf-8'))
 
 
-
 class SSOSessionCacheMem(SSOSessionCache):
     """
     This cache holds all SSO sessions, meaning information about what users
@@ -373,7 +370,7 @@ class SSOSessionCacheMDB(SSOSessionCache):
             res.append(this['session_id'])
         return res
 
-    def expire_old_sessions(self, force: bool=False) -> bool:
+    def expire_old_sessions(self, force: bool = False) -> bool:
         """
         Remove expired sessions from the MongoDB database.
 

--- a/src/eduid_common/session/sso_session.py
+++ b/src/eduid_common/session/sso_session.py
@@ -31,7 +31,7 @@
 #
 # Author : Fredrik Thulin <fredrik@thulin.net>
 #
-from typing import Optional, Dict
+from typing import Optional
 
 import time
 from eduid_common.session.logindata import ExternalMfaData

--- a/src/eduid_common/session/tests/test_eduid_session.py
+++ b/src/eduid_common/session/tests/test_eduid_session.py
@@ -2,8 +2,6 @@
 
 from typing import Optional, List, Dict, Any
 
-from flask import request
-
 from eduid_common.authn.middleware import AuthnBaseApp
 from eduid_common.api.testing import EduidAPITestCase
 from eduid_common.authn.utils import no_authn_views
@@ -51,7 +49,6 @@ def session_init_app(name, config):
 
 
 class EduidSessionTests(EduidAPITestCase):
-
 
     def setUp(self, users: Optional[List[str]] = None,
               copy_user_to_private: bool = False,

--- a/src/eduid_common/session/tests/test_redis_session.py
+++ b/src/eduid_common/session/tests/test_redis_session.py
@@ -32,7 +32,7 @@ class TestSession(TestCase):
         self.conn = FakeRedisConn()
         try:
             # Detect too old Python (like on CI) and skip tests
-            _x = derive_key('unittest', 'session', 'test', 16)
+            derive_key('unittest', 'session', 'test', 16)
         except AttributeError:
             self.skipTest('Python hashlib does not contain pbkdf2')
 
@@ -51,7 +51,7 @@ class TestSession(TestCase):
         # The ValueError is caught in the SessionFactory and triggers
         # the creation of a new, empty session.
         with self.assertRaises(ValueError):
-            session1 = self._get_session(token=None, data=None)
+            self._get_session(token=None, data=None)
 
     def test_clear_session(self):
         """ Test creating a session, clearing it and verifying it is gone """

--- a/src/eduid_common/stats/__init__.py
+++ b/src/eduid_common/stats/__init__.py
@@ -25,7 +25,8 @@ class NoOpStats(AppStats):
     Having this no-op class initialized in case there is no statsd_server
     configured allows us to not check if request.stats is set everywhere.
     """
-    def __init__(self, logger = None, prefix=None):
+
+    def __init__(self, logger=None, prefix=None):
         self.logger = logger
         self.prefix = prefix
 


### PR DESCRIPTION
Linter driven cleanup:

* remove unused imports,
* fix (according to pep8) indentation of continuation lines,
* add spaces around infix operators,
* adjust blank lines,
* remove unused local vars,
* and remove trailing whitespace.

Ignoring flake8 rules E501 (80 char wide lines) E251 (no spaces around = when calling functions) and W504 (no infix operators at the end of lines)