### PR TITLE
Eperez backdoors ng

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-version = '0.4.18'
+version = '0.4.19'
 
 requires = [
     'six >= 1.11.0',

--- a/src/eduid_common/api/helpers.py
+++ b/src/eduid_common/api/helpers.py
@@ -193,7 +193,7 @@ def check_magic_cookie(config: BaseConfig) -> bool:
     """
     This is for use in backdoor views, to check whether the backdoor is open.
 
-    Check that the environment allows the use of magic_cookies, that there is a magic cookie,
+    This checks that the environment allows the use of magic_cookies, that there is a magic cookie,
     and that the content of the magic cookie coincides with the configured magic cookie.
 
     :param config: A configuration object

--- a/src/eduid_common/api/helpers.py
+++ b/src/eduid_common/api/helpers.py
@@ -191,7 +191,7 @@ def send_mail(
 
 def check_magic_cookie(config: BaseConfig) -> bool:
     """
-    This is for use in backdoor views, to check whether the backdoor in open.
+    This is for use in backdoor views, to check whether the backdoor is open.
 
     Check that the environment allows the use of magic_cookies, that there is a magic cookie,
     and that the content of the magic cookie coincides with the configured magic cookie.

--- a/src/eduid_common/api/helpers.py
+++ b/src/eduid_common/api/helpers.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 from typing import List, Optional, Type
 
-from flask import current_app, render_template
+from flask import current_app, render_template, request
 
 from eduid_userdb.nin import Nin
 from eduid_userdb.proofing import ProofingUser
 from eduid_userdb.proofing.state import NinProofingState
 from eduid_userdb.user import User
+
+from eduid_common.config.base import BaseConfig
 
 from eduid_common.api.app import EduIDBaseApp
 
@@ -185,3 +187,18 @@ def send_mail(
     html = render_template(html_template, **context)
     app.logger.debug(f'rendered html: {html}')
     app.mail_relay.sendmail(subject, to_addresses, text, html, reference)
+
+
+def check_magic_cookie(config: BaseConfig) -> bool:
+    """
+    Check that the environment allows the use of magic_cookies, that there is a magic cookie,
+    and that the content of the magic cookie coincides with the configured magic cookie.
+
+    :param config: A configuration object
+    """
+    if config.environment in ('dev', 'staging') and config.magic_cookie and config.magic_cookie_name:
+        cookie = request.cookies.get(config.magic_cookie_name)
+        if cookie is not None:
+            return cookie == config.magic_cookie
+
+    return False

--- a/src/eduid_common/api/helpers.py
+++ b/src/eduid_common/api/helpers.py
@@ -191,6 +191,8 @@ def send_mail(
 
 def check_magic_cookie(config: BaseConfig) -> bool:
     """
+    This is for use in backdoor views, to check whether the backdoor in open.
+
     Check that the environment allows the use of magic_cookies, that there is a magic cookie,
     and that the content of the magic cookie coincides with the configured magic cookie.
 

--- a/src/eduid_common/api/testing.py
+++ b/src/eduid_common/api/testing.py
@@ -214,6 +214,13 @@ class EduidAPITestCase(CommonTestCase):
         client.set_cookie(server_name, key=self.app.config.session_cookie_name, value=sess._session.token)
         yield client
 
+    @contextmanager
+    def session_cookie_anon(self, client, server_name='localhost', **kwargs):
+        with client.session_transaction(**kwargs) as sess:
+            pass
+        client.set_cookie(server_name, key=self.app.config.session_cookie_name, value=sess._session.token)
+        yield client
+
     def request_user_sync(self, private_user):
         """
         Updates the central db user with data from the private db user.

--- a/src/eduid_common/api/tests/test_backdoor.py
+++ b/src/eduid_common/api/tests/test_backdoor.py
@@ -99,10 +99,18 @@ class BackdoorTests(EduidAPITestCase):
             response = client.get('/get-code?eppn=pepin-pepon')
             self.assertEqual(response.status_code, 400)
 
-    def test_no_backdoor_in_without_cookie(self):
+    def test_no_backdoor_without_cookie(self):
         """"""
         with self.session_cookie_anon(self.browser) as client:
 
+            response = client.get('/get-code?eppn=pepin-pepon')
+            self.assertEqual(response.status_code, 400)
+
+    def test_wrong_cookie_no_backdoor(self):
+        """"""
+        with self.session_cookie_anon(self.browser) as client:
+
+            client.set_cookie('localhost', key=self.app.config.magic_cookie_name, value='no-magic')
             response = client.get('/get-code?eppn=pepin-pepon')
             self.assertEqual(response.status_code, 400)
 

--- a/src/eduid_common/api/tests/test_backdoor.py
+++ b/src/eduid_common/api/tests/test_backdoor.py
@@ -1,0 +1,137 @@
+#  -*- encoding: utf-8 -*-
+#
+# Copyright (c) 2016 NORDUnet A/S
+# All rights reserved.
+#
+#   Redistribution and use in source and binary forms, with or
+#   without modification, are permitted provided that the following
+#   conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright
+#        notice, this list of conditions and the following disclaimer.
+#     2. Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided
+#        with the distribution.
+#     3. Neither the name of the NORDUnet nor the names of its
+#        contributors may be used to endorse or promote products derived
+#        from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+import logging
+from urllib.parse import unquote
+
+from flask import Blueprint, request, current_app, abort
+from marshmallow import ValidationError, fields
+from werkzeug.http import dump_cookie
+
+from eduid_userdb import UserDB
+
+from eduid_common.api.app import EduIDBaseApp
+from eduid_common.api.decorators import UnmarshalWith
+from eduid_common.api.helpers import check_magic_cookie
+from eduid_common.api.schemas.csrf import CSRFRequestMixin
+from eduid_common.api.testing import EduidAPITestCase
+from eduid_common.config.base import FlaskConfig
+from eduid_common.session.eduid_session import SessionFactory
+
+
+test_views = Blueprint('test', __name__)
+
+
+@test_views.route('/get-code', methods=['GET'])
+def get_code():
+    try:
+        if check_magic_cookie(current_app.config):
+            eppn = request.args.get('eppn')
+            return f"dummy-code-for-{eppn}"
+    except Exception:
+        pass
+
+    abort(400)
+
+
+class BackdoorTests(EduidAPITestCase):
+    def update_config(self, config):
+        """
+        Called from the parent class, so that we can update the configuration
+        according to the needs of this test case.
+        """
+        config.update(
+            {
+                'available_languages': {'en': 'English', 'sv': 'Svenska'},
+                'no_authn_urls': [r'/get-code'],
+                'environment': 'dev',
+                'magic_cookie_name': 'magic-cookie',
+                'magic_cookie': 'magic-cookie',
+            }
+        )
+        return config
+
+    def load_app(self, config):
+        """
+        Called from the parent class, so we can provide the appropriate flask
+        app for this test case.
+        """
+        app = EduIDBaseApp('testing', FlaskConfig, config)
+        app.register_blueprint(test_views)
+        app.session_interface = SessionFactory(app.config)
+        return app
+
+    def test_backdoor_get_code(self):
+        """"""
+        with self.session_cookie_anon(self.browser) as client:
+
+            client.set_cookie('localhost', key=self.app.config.magic_cookie_name, value=self.app.config.magic_cookie)
+            response = client.get('/get-code?eppn=pepin-pepon')
+            self.assertEqual(response.data, b'dummy-code-for-pepin-pepon')
+
+    def test_no_backdoor_in_pro(self):
+        """"""
+        self.app.config.environment = 'pro'
+
+        with self.session_cookie_anon(self.browser) as client:
+
+            client.set_cookie('localhost', key=self.app.config.magic_cookie_name, value=self.app.config.magic_cookie)
+            response = client.get('/get-code?eppn=pepin-pepon')
+            self.assertEqual(response.status_code, 400)
+
+    def test_no_backdoor_in_without_cookie(self):
+        """"""
+        with self.session_cookie_anon(self.browser) as client:
+
+            response = client.get('/get-code?eppn=pepin-pepon')
+            self.assertEqual(response.status_code, 400)
+
+    def test_no_magic_cookie_no_backdoor(self):
+        """"""
+        self.app.config.magic_cookie = ''
+
+        with self.session_cookie_anon(self.browser) as client:
+
+            client.set_cookie('localhost', key=self.app.config.magic_cookie_name, value=self.app.config.magic_cookie)
+            response = client.get('/get-code?eppn=pepin-pepon')
+            self.assertEqual(response.status_code, 400)
+
+    def test_no_magic_cookie_name_no_backdoor(self):
+        """"""
+        self.app.config.magic_cookie_name = ''
+
+        with self.session_cookie_anon(self.browser) as client:
+
+            client.set_cookie('localhost', key=self.app.config.magic_cookie_name, value=self.app.config.magic_cookie)
+            response = client.get('/get-code?eppn=pepin-pepon')
+            self.assertEqual(response.status_code, 400)

--- a/src/eduid_common/api/tests/test_backdoor.py
+++ b/src/eduid_common/api/tests/test_backdoor.py
@@ -30,20 +30,10 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-
-import logging
-from urllib.parse import unquote
-
 from flask import Blueprint, request, current_app, abort
-from marshmallow import ValidationError, fields
-from werkzeug.http import dump_cookie
-
-from eduid_userdb import UserDB
 
 from eduid_common.api.app import EduIDBaseApp
-from eduid_common.api.decorators import UnmarshalWith
 from eduid_common.api.helpers import check_magic_cookie
-from eduid_common.api.schemas.csrf import CSRFRequestMixin
 from eduid_common.api.testing import EduidAPITestCase
 from eduid_common.config.base import FlaskConfig
 from eduid_common.session.eduid_session import SessionFactory

--- a/src/eduid_common/api/tests/test_backdoor.py
+++ b/src/eduid_common/api/tests/test_backdoor.py
@@ -1,6 +1,6 @@
 #  -*- encoding: utf-8 -*-
 #
-# Copyright (c) 2016 NORDUnet A/S
+# Copyright (c) 2020 SUNET
 # All rights reserved.
 #
 #   Redistribution and use in source and binary forms, with or

--- a/src/eduid_common/config/base.py
+++ b/src/eduid_common/config/base.py
@@ -273,6 +273,10 @@ class BaseConfig(CommonConfig):
     stats_port: int = 8125
     sentry_dsn: Optional[str] = None
     status_cache_seconds: int = 10
+    # code to set in a "magic" cookie to bypass various verifications.
+    magic_cookie: Optional[str] = None
+    # name of the magic cookie
+    magic_cookie_name: Optional[str] = None
 
     @classmethod
     def init_config(

--- a/src/eduid_common/session/eduid_session.py
+++ b/src/eduid_common/session/eduid_session.py
@@ -16,9 +16,7 @@ from eduid_common.session.logindata import SSOLoginData
 from eduid_common.session.namespaces import (
     Actions,
     Common,
-    Email,
     MfaAction,
-    Phone,
     ResetPasswordNS,
     SessionNSBase,
     Signup,
@@ -60,8 +58,6 @@ class EduidSession(SessionMixin, MutableMapping):
         self._common: Optional[Common] = None
         self._mfa_action: Optional[MfaAction] = None
         self._signup: Optional[Signup] = None
-        self._phone: Optional[Phone] = None
-        self._email: Optional[Email] = None
         self._actions: Optional[Actions] = None
         self._sso_ticket: Optional[SSOLoginData] = None
         self._reset_password: Optional[ResetPasswordNS] = None
@@ -130,28 +126,6 @@ class EduidSession(SessionMixin, MutableMapping):
     def signup(self, value: Optional[Signup]):
         if not self._signup:
             self._signup = value
-
-    @property
-    def phone(self) -> Optional[Phone]:
-        if not self._phone:
-            self._phone = Phone.from_dict(self._session.get('_phone', {}))
-        return self._phone
-
-    @phone.setter
-    def phone(self, value: Optional[Phone]):
-        if not self._phone:
-            self._phone = value
-
-    @property
-    def email(self) -> Optional[Email]:
-        if not self._email:
-            self._email = Email.from_dict(self._session.get('_email', {}))
-        return self._email
-
-    @email.setter
-    def email(self, value: Optional[Email]):
-        if not self._email:
-            self._email = value
 
     @property
     def actions(self) -> Optional[Actions]:

--- a/src/eduid_common/session/eduid_session.py
+++ b/src/eduid_common/session/eduid_session.py
@@ -19,7 +19,6 @@ from eduid_common.session.namespaces import (
     MfaAction,
     ResetPasswordNS,
     SessionNSBase,
-    Signup,
 )
 from eduid_common.session.redis_session import RedisEncryptedSession, SessionManager
 
@@ -57,7 +56,6 @@ class EduidSession(SessionMixin, MutableMapping):
         # Namespaces
         self._common: Optional[Common] = None
         self._mfa_action: Optional[MfaAction] = None
-        self._signup: Optional[Signup] = None
         self._actions: Optional[Actions] = None
         self._sso_ticket: Optional[SSOLoginData] = None
         self._reset_password: Optional[ResetPasswordNS] = None
@@ -115,17 +113,6 @@ class EduidSession(SessionMixin, MutableMapping):
         self._mfa_action = None
         self._session.pop('_mfa_action', None)
         self.modified = True
-
-    @property
-    def signup(self) -> Optional[Signup]:
-        if not self._signup:
-            self._signup = Signup.from_dict(self._session.get('_signup', {}))
-        return self._signup
-
-    @signup.setter
-    def signup(self, value: Optional[Signup]):
-        if not self._signup:
-            self._signup = value
 
     @property
     def actions(self) -> Optional[Actions]:

--- a/src/eduid_common/session/eduid_session.py
+++ b/src/eduid_common/session/eduid_session.py
@@ -19,6 +19,7 @@ from eduid_common.session.namespaces import (
     MfaAction,
     ResetPasswordNS,
     SessionNSBase,
+    Signup,
 )
 from eduid_common.session.redis_session import RedisEncryptedSession, SessionManager
 
@@ -56,6 +57,7 @@ class EduidSession(SessionMixin, MutableMapping):
         # Namespaces
         self._common: Optional[Common] = None
         self._mfa_action: Optional[MfaAction] = None
+        self._signup: Optional[Signup] = None
         self._actions: Optional[Actions] = None
         self._sso_ticket: Optional[SSOLoginData] = None
         self._reset_password: Optional[ResetPasswordNS] = None
@@ -113,6 +115,17 @@ class EduidSession(SessionMixin, MutableMapping):
         self._mfa_action = None
         self._session.pop('_mfa_action', None)
         self.modified = True
+
+    @property
+    def signup(self) -> Optional[Signup]:
+        if not self._signup:
+            self._signup = Signup.from_dict(self._session.get('_signup', {}))
+        return self._signup
+
+    @signup.setter
+    def signup(self, value: Optional[Signup]):
+        if not self._signup:
+            self._signup = value
 
     @property
     def actions(self) -> Optional[Actions]:

--- a/src/eduid_common/session/namespaces.py
+++ b/src/eduid_common/session/namespaces.py
@@ -76,8 +76,6 @@ class TimestampedNS(SessionNSBase):
 @dataclass
 class ResetPasswordNS(SessionNSBase):
     generated_password_hash: Optional[str] = None
-    resetpw_email_verification_code: Optional[str] = None
-    resetpw_sms_verification_code: Optional[str] = None
     # XXX the keys below are not in use yet. They are set in eduid-common,
     # in a way that the security app understands. Once the (reset|change)
     # password views are removed from the security app, we will be able to
@@ -95,13 +93,3 @@ class Signup(TimestampedNS):
 @dataclass()
 class Actions(TimestampedNS):
     session: Optional[str] = None
-
-
-@dataclass()
-class Phone(TimestampedNS):
-    verification_code: Optional[str] = None
-
-
-@dataclass()
-class Email(TimestampedNS):
-    verification_code: Optional[str] = None

--- a/src/eduid_common/session/namespaces.py
+++ b/src/eduid_common/session/namespaces.py
@@ -86,5 +86,10 @@ class ResetPasswordNS(SessionNSBase):
 
 
 @dataclass()
+class Signup(TimestampedNS):
+    email_verification_code: Optional[str] = None
+
+
+@dataclass()
 class Actions(TimestampedNS):
     session: Optional[str] = None

--- a/src/eduid_common/session/namespaces.py
+++ b/src/eduid_common/session/namespaces.py
@@ -86,10 +86,5 @@ class ResetPasswordNS(SessionNSBase):
 
 
 @dataclass()
-class Signup(TimestampedNS):
-    email_verification_code: Optional[str] = None
-
-
-@dataclass()
 class Actions(TimestampedNS):
     session: Optional[str] = None

--- a/src/eduid_common/session/tests/test_eduid_session.py
+++ b/src/eduid_common/session/tests/test_eduid_session.py
@@ -48,23 +48,6 @@ def session_init_app(name, config):
     @app.route('/reset-password')
     def reset_password():
         session.reset_password.generated_password_hash = 'password-hash'
-        session.reset_password.resetpw_email_verification_code = 'email-code'
-        session.reset_password.resetpw_sms_verification_code = 'sms-code'
-        return 'Hello, World!'
-
-    @app.route('/signup')
-    def signup():
-        session.signup.email_verification_code = 'email-verification-code'
-        return 'Hello, World!'
-
-    @app.route('/phone')
-    def phone():
-        session.phone.verification_code = 'phone-verification-code'
-        return 'Hello, World!'
-
-    @app.route('/email')
-    def email():
-        session.email.verification_code = 'email-verification-code'
         return 'Hello, World!'
 
     return app
@@ -150,29 +133,6 @@ class EduidSessionTests(EduidAPITestCase):
             self.assertEqual(response.status_code, 200)
             with browser.session_transaction() as sess:
                 self.assertEqual(sess.reset_password.generated_password_hash, 'password-hash')
-                self.assertEqual(sess.reset_password.resetpw_email_verification_code, 'email-code')
-                self.assertEqual(sess.reset_password.resetpw_sms_verification_code, 'sms-code')
-
-    def test_session_signup(self):
-        with self.session_cookie(self.browser, self.test_user_eppn) as browser:
-            response = browser.get('/signup')
-            self.assertEqual(response.status_code, 200)
-            with browser.session_transaction() as sess:
-                self.assertEqual(sess.signup.email_verification_code, 'email-verification-code')
-
-    def test_session_phone(self):
-        with self.session_cookie(self.browser, self.test_user_eppn) as browser:
-            response = browser.get('/phone')
-            self.assertEqual(response.status_code, 200)
-            with browser.session_transaction() as sess:
-                self.assertEqual(sess.phone.verification_code, 'phone-verification-code')
-
-    def test_session_email(self):
-        with self.session_cookie(self.browser, self.test_user_eppn) as browser:
-            response = browser.get('/email')
-            self.assertEqual(response.status_code, 200)
-            with browser.session_transaction() as sess:
-                self.assertEqual(sess.email.verification_code, 'email-verification-code')
 
     def test_clear_session_mfa_action(self):
         with self.session_cookie(self.browser, self.test_user_eppn) as browser:

--- a/src/eduid_common/session/tests/test_eduid_session.py
+++ b/src/eduid_common/session/tests/test_eduid_session.py
@@ -50,6 +50,11 @@ def session_init_app(name, config):
         session.reset_password.generated_password_hash = 'password-hash'
         return 'Hello, World!'
 
+    @app.route('/signup')
+    def signup():
+        session.signup.email_verification_code = 'email-verification-code'
+        return 'Hello, World!'
+
     return app
 
 
@@ -133,6 +138,13 @@ class EduidSessionTests(EduidAPITestCase):
             self.assertEqual(response.status_code, 200)
             with browser.session_transaction() as sess:
                 self.assertEqual(sess.reset_password.generated_password_hash, 'password-hash')
+
+    def test_session_signup(self):
+        with self.session_cookie(self.browser, self.test_user_eppn) as browser:
+            response = browser.get('/signup')
+            self.assertEqual(response.status_code, 200)
+            with browser.session_transaction() as sess:
+                self.assertEqual(sess.signup.email_verification_code, 'email-verification-code')
 
     def test_clear_session_mfa_action(self):
         with self.session_cookie(self.browser, self.test_user_eppn) as browser:


### PR DESCRIPTION
* Remove session keys for verification codes for the old backdoors
* Add a `check_magic_cookie` method to use in the backdoor views
* test it