### PR TITLE
rework most parts of how flask view returned data is formatted

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-version = '0.4.26'
+version = '0.5.0'
 
 
 requires = [

--- a/src/eduid_common/api/am.py
+++ b/src/eduid_common/api/am.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
+import eduid_am
 from flask import current_app
 
 from eduid_userdb import User
 from eduid_userdb.exceptions import LockedIdentityViolation
 
-import eduid_am
 from eduid_common.api.app import EduIDBaseApp
 from eduid_common.api.exceptions import AmTaskFailed
 from eduid_common.config.base import CeleryConfig

--- a/src/eduid_common/api/decorators.py
+++ b/src/eduid_common/api/decorators.py
@@ -11,6 +11,7 @@ from marshmallow.exceptions import ValidationError
 from six import string_types
 from werkzeug.wrappers import Response as WerkzeugResponse
 
+from eduid_common.api.messages import FluxData, error_message
 from eduid_common.api.schemas.models import FluxFailResponse, FluxResponseStatus, FluxSuccessResponse
 from eduid_common.api.utils import get_user
 from eduid_common.session import session
@@ -68,11 +69,13 @@ def can_verify_identity(f):
         user = get_user()
         # For now a user can just have one verified NIN
         if user.nins.primary is not None:
-            return {'_status': FluxResponseStatus.error, 'message': 'User is already verified'}
+            # TODO: Make this a CommonMsg I guess
+            return error_message(message='User is already verified')
         # A user can not verify a nin if another previously was verified
         locked_nin = user.locked_identity.find('nin')
         if locked_nin and locked_nin.number != kwargs['nin']:
-            return {'_status': FluxResponseStatus.error, 'message': 'Another nin is already registered for this user'}
+            # TODO: Make this a CommonMsg I guess
+            return error_message(message='Another nin is already registered for this user')
 
         return f(*args, **kwargs)
 
@@ -80,34 +83,43 @@ def can_verify_identity(f):
 
 
 class MarshalWith(object):
+    """
+    Decorator to format the data returned from a Flask view and ensure it conforms to a marshmallow schema.
+
+    A common usage is to use this to format the response as a Flux Standard Action
+    (https://github.com/redux-utilities/flux-standard-action) by using a schema that has FluxStandardAction
+    as superclass, or as a mixin.
+
+    See the documentation of the FluxResponse class, or the link above, for more information about the
+    on-the-wire format of these Flux Standard Actions.
+    """
+
     def __init__(self, schema):
         self.schema = schema
 
     def __call__(self, f):
         @wraps(f)
         def marshal_decorator(*args, **kwargs):
+            # Call the Flask view, which is expected to return a FluxData instance,
+            # or in special cases an WerkzeugResponse (e.g. when a redirect is performed).
             ret = f(*args, **kwargs)
 
-            if isinstance(ret, WerkzeugResponse):  # No need to Marshal again, someone else already did that
+            if isinstance(ret, WerkzeugResponse):
+                # No need to Marshal again, someone else already did that
                 return ret
 
-            try:
-                response_status = ret.pop('_status', FluxResponseStatus.ok)
-            # ret may be a list:
-            except TypeError:
-                for item in ret:
-                    response_status = item.pop('_status', FluxResponseStatus.ok)
-                    if response_status != FluxResponseStatus.ok:
-                        break
+            if isinstance(ret, dict):
+                # TODO: Backwards compatibility mode - work on removing the need for this
+                ret = FluxData(FluxResponseStatus.OK, payload=ret)
 
-            # Handle fail responses
-            if response_status != FluxResponseStatus.ok:
-                response_data = FluxFailResponse(request, payload=ret)
-                return jsonify(self.schema().dump(response_data.to_dict()))
+            if not isinstance(ret, FluxData):
+                raise TypeError('Data returned from Flask view was not a FluxData (or WerkzeugResponse) instance')
 
-            # Handle success responses
-            response_data = FluxSuccessResponse(request, payload=ret)
-            return jsonify(self.schema().dump(response_data.to_dict()))
+            if ret.status != FluxResponseStatus.OK:
+                _flux_response = FluxFailResponse(request, payload=ret.payload)
+            else:
+                _flux_response = FluxSuccessResponse(request, payload=ret.payload)
+            return jsonify(self.schema().dump(_flux_response.to_dict()))
 
         return marshal_decorator
 

--- a/src/eduid_common/api/messages.py
+++ b/src/eduid_common/api/messages.py
@@ -30,12 +30,16 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
+from copy import copy
+from dataclasses import dataclass
 from enum import Enum, unique
-from typing import Optional, Union
+from typing import Any, Dict, Mapping, Optional, Union
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from flask import redirect
 from werkzeug.wrappers import Response as WerkzeugResponse
+
+from eduid_common.api.schemas.models import FluxResponseStatus
 
 
 @unique
@@ -72,38 +76,62 @@ class CommonMsg(TranslatableMsg):
     csrf_missing = 'csrf.missing'
 
 
-def success_message(message: Union[TranslatableMsg, str], data: Optional[dict] = None) -> dict:
+@dataclass(frozen=True)
+class FluxData:
+    status: FluxResponseStatus
+    payload: Mapping[str, Any]
+
+
+def success_message(
+    message: Optional[Union[TranslatableMsg, str]] = None, data: Optional[Mapping[str, Any]] = None
+) -> FluxData:
     """
-    Make a dict that corresponds to a success response, that can be marshalled into a response
-    that eduid-front understands.
+    Make a success response, that can be marshalled into a response that eduid-front understands.
+
+    See the documentation of the MarshalWith decorator for further details on the actual on-the-wire format.
 
     :param message: the code that will be translated in eduid-front into a message to the user.
                     can be an TranslatableMsg instance or, for B/C and robustness, a str.
     :param data: additional data the views may need to send in the response.
     """
-    if isinstance(message, TranslatableMsg):
-        message = str(message.value)
-    msg = {'_status': 'ok', 'success': True, 'message': message}
-    if data is not None:
-        msg.update(data)
-    return msg
+    return FluxData(status=FluxResponseStatus.OK, payload=_make_payload(message, data, True))
 
 
-def error_message(message: Union[TranslatableMsg, str], data: Optional[dict] = None) -> dict:
+def error_message(
+    message: Optional[Union[TranslatableMsg, str]] = None, data: Optional[Mapping[str, Any]] = None
+) -> FluxData:
     """
-    Make a dict that corresponds to an error response, that can be marshalled into a response
-    that eduid-front understands.
+    Make an error response, that can be marshalled into a response that eduid-front understands.
+
+    See the documentation of the MarshalWith decorator for further details on the actual on-the-wire format.
 
     :param message: the code that will be translated in eduid-front into a message to the user.
                     can be an SignupMsg instance or, for B/C and robustness, a str.
     :param data: additional data the views may need to send in the response.
     """
-    if isinstance(message, TranslatableMsg):
-        message = str(message.value)
-    msg = {'_status': 'error', 'success': False, 'message': message}
+    return FluxData(status=FluxResponseStatus.ERROR, payload=_make_payload(message, data, False))
+
+
+def _make_payload(
+    message: Optional[Union[TranslatableMsg, str]], data: Optional[Mapping[str, Any]], success: bool,
+) -> Mapping[str, Any]:
+    payload: Dict[str, Any] = {}
     if data is not None:
-        msg.update(data)
-    return msg
+        payload = copy(dict(data))  # to not mess with callers data
+
+    if message is not None:
+        if isinstance(message, TranslatableMsg):
+            payload['message'] = str(message.value)
+        elif isinstance(message, str):
+            payload['message'] = message
+        else:
+            raise TypeError('Flux message was neither a TranslatableMsg nor a string')
+
+    # TODO: See if the frontend actually uses this element, and if not - remove it (breaks some tests)
+    if 'success' not in payload:
+        payload['success'] = success
+
+    return payload
 
 
 def make_query_string(msg: TranslatableMsg, error: bool = True):

--- a/src/eduid_common/api/messages.py
+++ b/src/eduid_common/api/messages.py
@@ -71,7 +71,7 @@ class CommonMsg(TranslatableMsg):
     nin_invalid = 'nin needs to be formatted as 18|19|20yymmddxxxx'
     # Eamil address validation error
     email_invalid = 'email needs to be formatted according to RFC2822'
-    # CSRF
+    # TODO: These _should_ be unused now - check and remove
     csrf_try_again = 'csrf.try_again'
     csrf_missing = 'csrf.missing'
 

--- a/src/eduid_common/api/schemas/base.py
+++ b/src/eduid_common/api/schemas/base.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from marshmallow import RAISE, Schema, ValidationError, fields, validates_schema
+from marshmallow import RAISE, Schema, fields
 
 __author__ = 'lundberg'
 

--- a/src/eduid_common/api/schemas/models.py
+++ b/src/eduid_common/api/schemas/models.py
@@ -34,9 +34,9 @@ class FluxResponse(object):
         rv['type'] = self.flux_type
         if self.payload is not None:
             rv['payload'] = self.payload
-        if self.payload is not None:
+        if self.error is not None:
             rv['error'] = self.error
-        if self.payload is not None:
+        if self.meta is not None:
             rv['meta'] = self.meta
         return rv
 

--- a/src/eduid_common/api/schemas/password.py
+++ b/src/eduid_common/api/schemas/password.py
@@ -3,7 +3,6 @@
 import math
 
 from marshmallow import Schema, ValidationError
-
 from zxcvbn import zxcvbn
 
 __author__ = 'lundberg'

--- a/src/eduid_common/api/testing.py
+++ b/src/eduid_common/api/testing.py
@@ -279,6 +279,7 @@ class EduidAPITestCase(CommonTestCase):
                 self.assertIn('message', response.json['payload'], 'JSON payload has no "message" element')
                 self.assertEqual(message.value, response.json['payload']['message'], 'Wrong message returned')
             if error is not None:
+                self.assertTrue(response.json['error'], 'The Flux response was supposed to have error=True')
                 self.assertIn('error', response.json['payload'], 'JSON payload has no "error" element')
                 self.assertEqual(error, response.json['payload']['error'], 'Wrong error returned')
         except (AssertionError, KeyError):

--- a/src/eduid_common/api/testing.py
+++ b/src/eduid_common/api/testing.py
@@ -272,16 +272,16 @@ class EduidAPITestCase(CommonTestCase):
         :param error: Expected JSON error message
         """
         try:
-            self.assertEqual(status, response.status_code, f'The HTTP response code was not {status}')
-            self.assertEqual(type_, response.json['type'], 'Response had unexpected type')
-            self.assertIn('payload', response.json, 'JSON body has no "payload" element')
+            assert status == response.status_code, f'The HTTP response code was not {status}'
+            assert type_ == response.json['type'], 'Response had unexpected type'
+            assert 'payload' in response.json, 'JSON body has no "payload" element'
             if message is not None:
-                self.assertIn('message', response.json['payload'], 'JSON payload has no "message" element')
-                self.assertEqual(message.value, response.json['payload']['message'], 'Wrong message returned')
+                assert 'message' in response.json['payload'], 'JSON payload has no "message" element'
+                assert message.value == response.json['payload']['message'], 'Wrong message returned'
             if error is not None:
-                self.assertTrue(response.json['error'], 'The Flux response was supposed to have error=True')
-                self.assertIn('error', response.json['payload'], 'JSON payload has no "error" element')
-                self.assertEqual(error, response.json['payload']['error'], 'Wrong error returned')
+                assert response.json['error'] == True, 'The Flux response was supposed to have error=True'
+                assert 'error' in response.json['payload'], 'JSON payload has no "error" element'
+                assert error == response.json['payload']['error'], 'Wrong error returned'
         except (AssertionError, KeyError):
             if response.json:
                 logger.info(

--- a/src/eduid_common/api/tests/test_decorators.py
+++ b/src/eduid_common/api/tests/test_decorators.py
@@ -1,0 +1,64 @@
+from unittest.case import TestCase
+
+import flask
+
+from eduid_common.api.decorators import MarshalWith
+from eduid_common.api.messages import FluxData, error_message, success_message
+from eduid_common.api.schemas.base import FluxStandardAction
+from eduid_common.api.tests.test_messages import TestsMsg
+
+test_views = flask.Blueprint('test', __name__, url_prefix='/test', template_folder='templates')
+
+
+class MarshalDecoratorTests(TestCase):
+    def setUp(self) -> None:
+        self.app = flask.Flask(__name__)
+        self.app.register_blueprint(test_views)
+
+    @MarshalWith(FluxStandardAction)
+    @test_views.route('/foo', methods=['GET'])
+    def flask_view(self, ret: FluxData):
+        """ Fake flask view, returning a FluxData that will be turned into a FluxResponse by the decorator. """
+        return ret
+
+    def test_success_message(self):
+        """ Test that a simple success_message is turned into a well-formed Flux Standard Action response"""
+        msg = success_message(TestsMsg.fst_test_msg)
+        with self.app.test_request_context('/test/foo'):
+            response = self.flask_view(msg)
+            assert response.json == {
+                'type': 'GET_TEST_TEST_FOO_SUCCESS',
+                'payload': {'message': 'test.first_msg', 'success': True},
+            }
+
+    def test_success_message_with_data(self):
+        """ Test that a success_message with data is turned into a well-formed Flux Standard Action response"""
+        msg = success_message(TestsMsg.fst_test_msg, data={'working': True})
+        with self.app.test_request_context('/test/foo'):
+            response = self.flask_view(msg)
+            assert response.json == {
+                'type': 'GET_TEST_TEST_FOO_SUCCESS',
+                'payload': {'message': 'test.first_msg', 'success': True, 'working': True},
+            }
+
+    def test_error_message(self):
+        """ Test that a simple success_message is turned into a well-formed Flux Standard Action response"""
+        msg = error_message(TestsMsg.fst_test_msg)
+        with self.app.test_request_context('/test/foo'):
+            response = self.flask_view(msg)
+            assert response.json == {
+                'type': 'GET_TEST_TEST_FOO_FAIL',
+                'error': True,
+                'payload': {'message': 'test.first_msg', 'success': False},
+            }
+
+    def test_error_message_with_data(self):
+        """ Test that an error_message with data is turned into a well-formed Flux Standard Action response"""
+        msg = error_message(TestsMsg.fst_test_msg, data={'working': True})
+        with self.app.test_request_context('/test/foo'):
+            response = self.flask_view(msg)
+            assert response.json == {
+                'type': 'GET_TEST_TEST_FOO_FAIL',
+                'error': True,
+                'payload': {'message': 'test.first_msg', 'success': False, 'working': True},
+            }

--- a/src/eduid_common/api/tests/test_messages.py
+++ b/src/eduid_common/api/tests/test_messages.py
@@ -34,8 +34,6 @@
 from enum import unique
 from unittest import TestCase
 
-from werkzeug.wrappers import Response
-
 from eduid_common.api.messages import (
     CommonMsg,
     TranslatableMsg,
@@ -44,6 +42,7 @@ from eduid_common.api.messages import (
     redirect_with_msg,
     success_message,
 )
+from eduid_common.api.schemas.models import FluxResponseStatus
 
 
 @unique
@@ -55,28 +54,25 @@ class TestsMsg(TranslatableMsg):
 class MessageTests(TestCase):
     def test_success_message(self):
         message = success_message(TestsMsg.fst_test_msg)
-        self.assertEqual(message['_status'], 'ok')
-        self.assertTrue(message['success'])
-        self.assertEqual(message['message'], 'test.first_msg')
+        assert message.status == FluxResponseStatus.OK
+        assert message.payload == dict(message=TestsMsg.fst_test_msg.value, success=True)
 
     def test_success_message_with_data(self):
         data = {'email': 'test@example.com'}
         message = success_message(TestsMsg.fst_test_msg, data=data)
-        self.assertEqual(message['_status'], 'ok')
-        self.assertEqual(message['message'], 'test.first_msg')
-        self.assertEqual(message['email'], 'test@example.com')
+        assert message.status == FluxResponseStatus.OK
+        assert message.payload == dict(message=TestsMsg.fst_test_msg.value, success=True, email='test@example.com')
 
     def test_success_message_from_str(self):
         message = success_message('test.str_msg')
-        self.assertEqual(message['_status'], 'ok')
-        self.assertEqual(message['message'], 'test.str_msg')
+        assert message.status == FluxResponseStatus.OK
+        assert message.payload == dict(message='test.str_msg', success=True)
 
     def test_success_message_from_str_with_data(self):
         data = {'email': 'test@example.com'}
         message = success_message('test.str_msg', data=data)
-        self.assertEqual(message['_status'], 'ok')
-        self.assertEqual(message['message'], 'test.str_msg')
-        self.assertEqual(message['email'], 'test@example.com')
+        assert message.status == FluxResponseStatus.OK
+        assert message.payload == dict(message='test.str_msg', success=True, email='test@example.com')
 
     def test_success_message_unknown(self):
         with self.assertRaises(AttributeError):
@@ -89,56 +85,49 @@ class MessageTests(TestCase):
 
     def test_error_message(self):
         message = error_message(TestsMsg.fst_test_msg)
-        self.assertEqual(message['_status'], 'error')
-        self.assertFalse(message['success'])
-        self.assertEqual(message['message'], 'test.first_msg')
+        assert message.status == FluxResponseStatus.ERROR
+        assert message.payload == dict(message=TestsMsg.fst_test_msg.value, success=False)
 
     def test_error_message_with_errors(self):
         data = {'errors': {'email': 'required'}}
         message = error_message(TestsMsg.fst_test_msg, data=data)
-        self.assertEqual(message['_status'], 'error')
-        self.assertEqual(message['message'], 'test.first_msg')
-        self.assertEqual(message['errors'], data['errors'])
+        assert message.status == FluxResponseStatus.ERROR
+        assert message.payload == dict(message=TestsMsg.fst_test_msg.value, success=False, errors=data['errors'])
 
     def test_error_message_with_status(self):
         data = {'status': 'stale'}
         message = error_message(TestsMsg.fst_test_msg, data=data)
-        self.assertEqual(message['_status'], 'error')
-        self.assertEqual(message['message'], 'test.first_msg')
-        self.assertEqual(message['status'], data['status'])
+        assert message.status == FluxResponseStatus.ERROR
+        assert message.payload == dict(message=TestsMsg.fst_test_msg.value, success=False, status=data['status'])
 
     def test_error_message_with_next(self):
         data = {'next': '/next'}
         message = error_message(TestsMsg.fst_test_msg, data=data)
-        self.assertEqual(message['_status'], 'error')
-        self.assertEqual(message['message'], 'test.first_msg')
-        self.assertEqual(message['next'], data['next'])
+        assert message.status == FluxResponseStatus.ERROR
+        assert message.payload == dict(message=TestsMsg.fst_test_msg.value, success=False, next=data['next'])
 
     def test_error_message_from_str(self):
         message = error_message('test.str_msg')
-        self.assertEqual(message['_status'], 'error')
-        self.assertEqual(message['message'], 'test.str_msg')
+        assert message.status == FluxResponseStatus.ERROR
+        assert message.payload == dict(message='test.str_msg', success=False)
 
     def test_error_message_from_str_with_errors(self):
         data = {'errors': {'email': 'required'}}
         message = error_message('str_msg', data=data)
-        self.assertEqual(message['_status'], 'error')
-        self.assertEqual(message['message'], 'str_msg')
-        self.assertEqual(message['errors'], data['errors'])
+        assert message.status == FluxResponseStatus.ERROR
+        assert message.payload == dict(message='str_msg', success=False, errors=data['errors'])
 
     def test_error_message_from_str_with_status(self):
         data = {'status': 'stale'}
         message = error_message('str_msg', data=data)
-        self.assertEqual(message['_status'], 'error')
-        self.assertEqual(message['message'], 'str_msg')
-        self.assertEqual(message['status'], data['status'])
+        assert message.status == FluxResponseStatus.ERROR
+        assert message.payload == dict(message='str_msg', success=False, status=data['status'])
 
     def test_error_message_from_str_with_next(self):
         data = {'next': '/next'}
         message = error_message('str_msg', data=data)
-        self.assertEqual(message['_status'], 'error')
-        self.assertEqual(message['message'], 'str_msg')
-        self.assertEqual(message['next'], data['next'])
+        assert message.status == FluxResponseStatus.ERROR
+        assert message.payload == dict(message='str_msg', success=False, next=data['next'])
 
     def test_error_message_unknown(self):
         with self.assertRaises(AttributeError):

--- a/src/eduid_common/api/utils.py
+++ b/src/eduid_common/api/utils.py
@@ -165,6 +165,9 @@ def get_flux_type(req: Request, suffix: str) -> str:
     """
     method = req.method
     blueprint = req.blueprint
+    if req.url_rule is None:
+        # mainly please mypy - but this can also happen when testing if a view doesn't have proper routing set up
+        raise ValueError('No Flask url_rule present in request')
     # req.url_rule.rule is e.g. '/reset/config', but can also be '/', '/reset/' or '/verify-link/<code>'
     url_rule = req.url_rule.rule
     # Remove APPLICATION_ROOT from request url rule


### PR DESCRIPTION
    I had a hard time understanding exactly how returned data was consumed
    by the frontend code, so to try and improve this for the next person to
    come along I added lots of documentation and questioned a lot of how
    this is currently done and explained things as well as I could :).

    Also, I felt that a proper data container (FluxData rather than a dict
    with 'special' elements like '_status') to transport data from the
    success_message/error_message functions into the MarshalWith decorator,
    where it was turned into a FluxResponse would be more robust.