### PR TITLE
Bump mail sending timeout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-version = '0.7.8'
+version = '0.7.9'
 
 
 requires = [

--- a/src/eduid_common/api/mail_relay.py
+++ b/src/eduid_common/api/mail_relay.py
@@ -59,7 +59,7 @@ class MailRelay(object):
         text: Optional[str] = None,
         html: Optional[str] = None,
         reference: Optional[str] = None,
-        timeout: int = 4,
+        timeout: int = 25,
     ):
         """
         :param subject: Message subject


### PR DESCRIPTION
Keep the timeout under gunicorns default timeout (30s)