### PR TITLE
Eperez elem init 4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ version = '0.7.10'
 requires = [
     'six >= 1.11.0',
     'setuptools >= 2.2',
-    'eduid-userdb >= 0.4.18',
+    'eduid-userdb >= 0.5.0',
 ]
 
 # Flavours

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-version = '0.7.10'
+version = '0.7.11'
 
 
 requires = [

--- a/src/eduid_common/api/helpers.py
+++ b/src/eduid_common/api/helpers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import warnings
+from datetime import datetime
 from typing import List, Optional, Type, Union
 
 from flask import current_app, render_template, request
@@ -89,7 +90,7 @@ def add_nin_to_user(user: User, proofing_state: NinProofingState, user_class: Ty
             )
         )
         proofing_user.nins.add(nin_element)
-        proofing_user.modified_ts = True
+        proofing_user.modified_ts = datetime.utcnow()
         # Save user to private db
         current_app.private_userdb.save(proofing_user, check_sync=False)
         # Ask am to sync user to central db

--- a/src/eduid_common/api/oidc.py
+++ b/src/eduid_common/api/oidc.py
@@ -3,11 +3,10 @@
 from sys import exit
 from time import sleep
 
-from requests.exceptions import ConnectionError
-
 from oic.oic import Client
 from oic.oic.message import RegistrationRequest
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
+from requests.exceptions import ConnectionError
 
 __author__ = 'lundberg'
 

--- a/src/eduid_common/api/oidc.py
+++ b/src/eduid_common/api/oidc.py
@@ -3,10 +3,11 @@
 from sys import exit
 from time import sleep
 
+from requests.exceptions import ConnectionError
+
 from oic.oic import Client
 from oic.oic.message import RegistrationRequest
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
-from requests.exceptions import ConnectionError
 
 __author__ = 'lundberg'
 

--- a/src/eduid_common/api/schemas/password.py
+++ b/src/eduid_common/api/schemas/password.py
@@ -3,6 +3,7 @@
 import math
 
 from marshmallow import Schema, ValidationError
+
 from zxcvbn import zxcvbn
 
 __author__ = 'lundberg'

--- a/src/eduid_common/api/testing.py
+++ b/src/eduid_common/api/testing.py
@@ -116,9 +116,10 @@ class EduidAPITestCase(CommonTestCase):
 
     def setUp(
         self,
+        init_am: bool = False,
+        am_settings: Optional[Dict[str, Any]] = None,
         users: Optional[List[str]] = None,
         copy_user_to_private: bool = False,
-        am_settings: Optional[Dict[str, Any]] = None,
     ):
         """
         set up tests
@@ -137,7 +138,7 @@ class EduidAPITestCase(CommonTestCase):
         self.test_user_data = _standard_test_users[users[0]].to_dict()
         self.test_user = User.from_dict(self.test_user_data)
 
-        super(EduidAPITestCase, self).setUp(users=users, am_settings=am_settings)
+        super(EduidAPITestCase, self).setUp(init_am=init_am, am_settings=am_settings, users=users)
         # Set up Redis for shared sessions
         self.redis_instance = RedisTemporaryInstance.get_instance()
         # settings

--- a/src/eduid_common/api/testing_base.py
+++ b/src/eduid_common/api/testing_base.py
@@ -52,14 +52,15 @@ class CommonTestCase(MongoTestCase):
 
     def setUp(
         self,
+        init_am: bool = False,
+        am_settings: Optional[Dict[str, Any]] = None,
         users: Optional[List[str]] = None,
         copy_user_to_private: bool = False,
-        am_settings: Optional[Dict[str, Any]] = None,
     ):
         """
         set up tests
         """
-        super(CommonTestCase, self).setUp()
+        super(CommonTestCase, self).setUp(init_am=init_am, am_settings=am_settings)
 
         # setup AM
         celery_settings = {

--- a/src/eduid_common/api/tests/test_logging.py
+++ b/src/eduid_common/api/tests/test_logging.py
@@ -25,7 +25,9 @@ class LoggingTest(EduidAPITestCase):
         copy_user_to_private: bool = False,
     ):
 
-        super(LoggingTest, self).setUp(init_am=init_am, am_settings=am_settings, users=users, copy_user_to_private=copy_user_to_private)
+        super(LoggingTest, self).setUp(
+            init_am=init_am, am_settings=am_settings, users=users, copy_user_to_private=copy_user_to_private
+        )
 
     def load_app(self, config):
         """

--- a/src/eduid_common/api/tests/test_logging.py
+++ b/src/eduid_common/api/tests/test_logging.py
@@ -19,12 +19,13 @@ class LoggingTestApp(EduIDBaseApp):
 class LoggingTest(EduidAPITestCase):
     def setUp(
         self,
+        init_am: bool = False,
+        am_settings: Optional[Dict[str, Any]] = None,
         users: Optional[List[str]] = None,
         copy_user_to_private: bool = False,
-        am_settings: Optional[Dict[str, Any]] = None,
     ):
 
-        super(LoggingTest, self).setUp(users=users, copy_user_to_private=copy_user_to_private, am_settings=am_settings)
+        super(LoggingTest, self).setUp(init_am=init_am, am_settings=am_settings, users=users, copy_user_to_private=copy_user_to_private)
 
     def load_app(self, config):
         """

--- a/src/eduid_common/api/tests/test_nin_helpers.py
+++ b/src/eduid_common/api/tests/test_nin_helpers.py
@@ -69,12 +69,7 @@ class NinHelpersTest(EduidAPITestCase):
         del userdata['nins']
         user = User.from_dict(data=userdata)
         nin_element = Nin.from_dict(
-            dict(
-                number=self.test_user_nin,
-                created_by='AlreadyVerifiedNinHelpersTest',
-                verified=True,
-                primary=True,
-            )
+            dict(number=self.test_user_nin, created_by='AlreadyVerifiedNinHelpersTest', verified=True, primary=True,)
         )
         user.nins.add(nin_element)
         self.app.central_userdb.save(user, check_sync=False)
@@ -85,12 +80,7 @@ class NinHelpersTest(EduidAPITestCase):
         del userdata['nins']
         user = User.from_dict(data=userdata)
         nin_element = Nin.from_dict(
-            dict(
-                number=self.test_user_nin,
-                created_by='AlreadyAddedNinHelpersTest',
-                verified=False,
-                primary=False,
-            )
+            dict(number=self.test_user_nin, created_by='AlreadyAddedNinHelpersTest', verified=False, primary=False,)
         )
         user.nins.add(nin_element)
         self.app.central_userdb.save(user, check_sync=False)

--- a/src/eduid_common/api/tests/test_nin_helpers.py
+++ b/src/eduid_common/api/tests/test_nin_helpers.py
@@ -163,7 +163,7 @@ class NinHelpersTest(EduidAPITestCase):
         )
         proofing_state = NinProofingState.from_dict({'eduPersonPrincipalName': eppn, 'nin': nin_element.to_dict()})
         proofing_log_entry = NinProofingLogElement(
-            user,
+            eppn=user.eppn,
             created_by=proofing_state.nin.created_by,
             nin=proofing_state.nin.number,
             user_postal_address=self.navet_response,
@@ -198,7 +198,7 @@ class NinHelpersTest(EduidAPITestCase):
         )
         proofing_state = NinProofingState.from_dict({'eduPersonPrincipalName': eppn, 'nin': nin_element.to_dict()})
         proofing_log_entry = NinProofingLogElement(
-            user,
+            eppn=user.eppn,
             created_by=proofing_state.nin.created_by,
             nin=proofing_state.nin.number,
             user_postal_address=self.navet_response,
@@ -238,7 +238,7 @@ class NinHelpersTest(EduidAPITestCase):
         )
         proofing_state = NinProofingState.from_dict({'eduPersonPrincipalName': eppn, 'nin': nin_element.to_dict()})
         proofing_log_entry = NinProofingLogElement(
-            user,
+            eppn=user.eppn,
             created_by=proofing_state.nin.created_by,
             nin=proofing_state.nin.number,
             user_postal_address=self.navet_response,
@@ -280,7 +280,7 @@ class NinHelpersTest(EduidAPITestCase):
         proofing_state = NinProofingState.from_dict({'eduPersonPrincipalName': eppn, 'nin': nin_element.to_dict()})
         # Create a ProofingLogElement with an empty created_by, which should be rejected on save in LogDB
         proofing_log_entry = NinProofingLogElement(
-            user,
+            eppn=user.eppn,
             created_by='',
             nin=proofing_state.nin.number,
             user_postal_address=self.navet_response,
@@ -299,7 +299,7 @@ class NinHelpersTest(EduidAPITestCase):
         del userdata['displayName']
         user = ProofingUser.from_dict(data=userdata)
         proofing_element = NinProofingLogElement(
-            user,
+            eppn=user.eppn,
             created_by='test',
             nin='190102031234',
             user_postal_address=self.navet_response,
@@ -321,7 +321,7 @@ class NinHelpersTest(EduidAPITestCase):
             u'OfficialAddress': {u'Address2': u'\xd6RGATAN 79 LGH 10', u'City': u'LANDET', u'PostalCode': u'12345'},
         }
         proofing_element = NinProofingLogElement(
-            user,
+            eppn=user.eppn,
             created_by='test',
             nin='190102031234',
             user_postal_address=navet_response,
@@ -347,7 +347,7 @@ class NinHelpersTest(EduidAPITestCase):
             u'OfficialAddress': {u'Address2': u'\xd6RGATAN 79 LGH 10', u'City': u'LANDET', u'PostalCode': u'12345'},
         }
         proofing_element = NinProofingLogElement(
-            user,
+            eppn=user.eppn,
             created_by='test',
             nin='190102031234',
             user_postal_address=navet_response,
@@ -369,7 +369,7 @@ class NinHelpersTest(EduidAPITestCase):
             u'OfficialAddress': {u'Address2': u'\xd6RGATAN 79 LGH 10', u'City': u'LANDET', u'PostalCode': u'12345'},
         }
         proofing_element = NinProofingLogElement(
-            user,
+            eppn=user.eppn,
             created_by='test',
             nin='190102031234',
             user_postal_address=navet_response,
@@ -386,7 +386,7 @@ class NinHelpersTest(EduidAPITestCase):
         userdata = new_user_example.to_dict()
         user = ProofingUser.from_dict(data=userdata)
         proofing_element = NinProofingLogElement(
-            user,
+            eppn=user.eppn,
             created_by='test',
             nin='190102031234',
             user_postal_address=self.navet_response,

--- a/src/eduid_common/api/tests/test_nin_helpers.py
+++ b/src/eduid_common/api/tests/test_nin_helpers.py
@@ -73,12 +73,10 @@ class NinHelpersTest(EduidAPITestCase):
                 number=self.test_user_nin,
                 created_by='AlreadyVerifiedNinHelpersTest',
                 verified=True,
-                created_ts=True,
                 primary=True,
             )
         )
         user.nins.add(nin_element)
-        user.modified_ts = True
         self.app.central_userdb.save(user, check_sync=False)
         return user.eppn
 
@@ -91,12 +89,10 @@ class NinHelpersTest(EduidAPITestCase):
                 number=self.test_user_nin,
                 created_by='AlreadyAddedNinHelpersTest',
                 verified=False,
-                created_ts=True,
                 primary=False,
             )
         )
         user.nins.add(nin_element)
-        user.modified_ts = True
         self.app.central_userdb.save(user, check_sync=False)
         return user.eppn
 
@@ -105,7 +101,6 @@ class NinHelpersTest(EduidAPITestCase):
         userdata = new_user_example.to_dict()
         del userdata['nins']
         user = User.from_dict(data=userdata)
-        user.modified_ts = True
         self.app.central_userdb.save(user, check_sync=False)
         return user.eppn
 

--- a/src/eduid_common/api/translation.py
+++ b/src/eduid_common/api/translation.py
@@ -3,9 +3,9 @@
 from __future__ import absolute_import
 
 from flask import request
+from flask_babel import Babel
 
 from eduid_common.api.app import EduIDBaseApp
-from flask_babel import Babel
 
 __author__ = 'lundberg'
 

--- a/src/eduid_common/api/utils.py
+++ b/src/eduid_common/api/utils.py
@@ -102,14 +102,11 @@ def save_and_sync_user(user):
     return current_app.am_relay.request_user_sync(user)
 
 
-def urlappend(base, path):
+def urlappend(base: str, path: str) -> str:
     """
     :param base: Base url
-    :type base: six.string_types
     :param path: Path to join to base
-    :type path: six.string_types
     :return: Joined url
-    :rtype: six.string_types
 
     Used instead of urlparse.urljoin to append path to base in an obvious way.
 

--- a/src/eduid_common/api/utils.py
+++ b/src/eduid_common/api/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import re
+from datetime import datetime
 from typing import Optional
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -50,7 +51,7 @@ def update_modified_ts(user):
         return
 
     if private_user.modified_ts is None:
-        private_user.modified_ts = True  # use current time
+        private_user.modified_ts = datetime.utcnow()  # use current time
         current_app.logger.debug(
             "Updating user {!s} with new modified_ts: {!s}".format(private_user, private_user.modified_ts)
         )

--- a/src/eduid_common/session/tests/test_eduid_session.py
+++ b/src/eduid_common/session/tests/test_eduid_session.py
@@ -67,12 +67,13 @@ def session_init_app(name, config):
 class EduidSessionTests(EduidAPITestCase):
     def setUp(
         self,
+        init_am: bool = False,
+        am_settings: Optional[Dict[str, Any]] = None,
         users: Optional[List[str]] = None,
         copy_user_to_private: bool = False,
-        am_settings: Optional[Dict[str, Any]] = None,
     ):
         self.test_user_eppn = 'hubba-bubba'
-        super().setUp(users=users, copy_user_to_private=copy_user_to_private, am_settings=am_settings)
+        super().setUp(init_am=init_am, am_settings=am_settings, users=users, copy_user_to_private=copy_user_to_private)
 
     def load_app(self, config):
         """


### PR DESCRIPTION
Turning Element into a dataclass

* Assign datetimes rather than booleans to `modified_ts`
* Rely on the default value for `modified_ts` to set it to now rather than by providing `True`
* The `NinProofingLogElement` constructor now takes an eppn rather than a user
* make reformat things
