### PR TITLE
heavily refactor dictConfig setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-version = '0.16.1'
+version = '0.17.0'
 
 
 requires = [

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-version = '0.16.0'
+version = '0.16.1'
 
 
 requires = [

--- a/src/eduid_common/api/logging.py
+++ b/src/eduid_common/api/logging.py
@@ -28,7 +28,7 @@ app_name - Flask app name
 eppn - Available if a user session is initiated
 """
 
-DEFAULT_FORMAT = '{asctime} | {levelname:7} | {hostname} | {eppn:9} | {name:35} | {module:10} | {message}'
+DEFAULT_FORMAT = '{asctime} | {levelname:7} | {hostname} | {eppn:11} | {name:35} | {module:10} | {message}'
 
 
 # Default to RFC3339/ISO 8601 with tz

--- a/src/eduid_common/api/logging.py
+++ b/src/eduid_common/api/logging.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import logging
 import logging.config
 import time
+from dataclasses import asdict, dataclass, field
+from enum import Enum, unique
 from os import environ
-from pprint import PrettyPrinter
-from typing import TYPE_CHECKING, Sequence
+from pprint import pformat
+from typing import TYPE_CHECKING, Any, Dict, List, Sequence
 
 from eduid_common.config.exceptions import BadConfiguration
 from eduid_common.session import session
@@ -33,7 +35,16 @@ DEFAULT_FORMAT = '{asctime} | {levelname:7} | {hostname} | {eppn:11} | {name:35}
 
 # Default to RFC3339/ISO 8601 with tz
 class EduidFormatter(logging.Formatter):
+    def __init__(self, relative_time: bool = False, fmt=None):
+        super().__init__(fmt=fmt, style='{')
+        self._relative_time = relative_time
+
     def formatTime(self, record: logging.LogRecord, datefmt=None) -> str:
+        if self._relative_time:
+            # Relative time makes much more sense than absolute time when running tests for example
+            _seconds = record.relativeCreated / 1000
+            return f'{_seconds:.3f}s'
+
         # self.converter seems incorrectly typed as a two-argument method (Callable[[Optional[float]], struct_time])
         ct = self.converter(record.created)  # type: ignore
         if datefmt:
@@ -47,31 +58,32 @@ class EduidFormatter(logging.Formatter):
         return s
 
 
-class DebugTimeFilter(logging.Filter):
-    """ A filter to add record.debugTime which is time since the logger was initialised in a fixed format """
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        _seconds = record.relativeCreated / 1000
-        record.__setattr__('debugTime', f'{_seconds:.3f}s')  # use setattr to prevent mypy unhappiness
-        return True
-
-
 class AppFilter(logging.Filter):
+    """ Add `system_hostname`, `hostname` and `app_name` to records being logged. """
+
     def __init__(self, app_name):
         super().__init__()
         self.app_name = app_name
+        # TODO: I guess it could be argued that these should be put in the LocalContext and not evaluated at runtime.
+        self.hostname = environ.get('HOSTNAME', '')
+        self.system_hostname = environ.get('SYSTEM_HOSTNAME', '')
 
     def filter(self, record: logging.LogRecord) -> bool:
         # use setattr to prevent mypy unhappiness
-        record.__setattr__(
-            'system_hostname', environ.get('SYSTEM_HOSTNAME', '')
-        )  # Underlying hosts name for containers
-        record.__setattr__('hostname', environ.get('HOSTNAME', ''))  # Actual hostname or container id
         record.__setattr__('app_name', self.app_name)
+        record.__setattr__('hostname', self.hostname)  # Actual hostname or container id
+        record.__setattr__('system_hostname', self.system_hostname)  # Underlying hosts name for containers
         return True
 
 
 class UserFilter(logging.Filter):
+    """
+    A filter to add eppn to the log records.
+
+    Additionally, if debug_eppns is set, only allow debug log entries where the eppn is found in debug_eppns.
+    This allows us to debug-log certain users in production, without having debug logging enabled for everyone.
+    """
+
     def __init__(self, debug_eppns: Sequence[str]):
         super().__init__()
         self.debug_eppns = debug_eppns
@@ -91,6 +103,8 @@ class UserFilter(logging.Filter):
 
 
 class RequireDebugTrue(logging.Filter):
+    """ A filter to discard all debug log records if the Flask app.debug is not True. Generally not used. """
+
     def __init__(self, app_debug: bool):
         super().__init__()
         self.app_debug = app_debug
@@ -100,6 +114,8 @@ class RequireDebugTrue(logging.Filter):
 
 
 class RequireDebugFalse(logging.Filter):
+    """ A filter to discard all debug log records if the Flask app.debug is not False. Generally not used. """
+
     def __init__(self, app_debug: bool):
         super().__init__()
         self.app_debug = app_debug
@@ -108,7 +124,9 @@ class RequireDebugFalse(logging.Filter):
         return not self.app_debug
 
 
-def merge_config(base_config: dict, new_config: dict) -> dict:
+def merge_config(base_config: Dict[str, Any], new_config: Dict[str, Any]) -> Dict[str, Any]:
+    """ Recursively merge two dictConfig dicts. """
+
     def merge(node, key, value):
         if isinstance(value, dict):
             for item in value:
@@ -127,72 +145,144 @@ def merge_config(base_config: dict, new_config: dict) -> dict:
 
 def init_logging(app: EduIDBaseApp) -> None:
     """
-    Init logging using dictConfig.
+    Init logging in a Flask app using dictConfig.
 
-    Will look for the following settings keys:
-    LOG_LEVEL
-    LOG_FORMAT (optional)
+    See `make_local_context` for how to configure logging.
 
-    Merges optional dictConfig from settings before initializing.
+    Merges optional dictConfig from settings before initializing (config key 'logging_config').
     """
-    try:
-        local_context = {
-            'level': app.config.setdefault('log_level', 'INFO'),
-            'format': app.config.setdefault('log_format', DEFAULT_FORMAT),
-            'app_name': app.name,
-            'app_debug': app.debug,
-            'debug_eppns': app.config.debug_eppns,
-        }
-    except (KeyError, AttributeError) as e:
-        raise BadConfiguration(message=f'Could not initialize logging local_context. {type(e).__name__}: {e}')
+    local_context = make_local_context(app)
+    logging_config = make_dictConfig(local_context)
 
+    logging_config = merge_config(logging_config, app.config.logging_config)
+
+    logging.config.dictConfig(logging_config)
+    if app.debug:
+        app.logger.debug(f'Logging config:\n{pformat(logging_config)}')
+    app.logger.info('Logging configured')
+    return None
+
+
+@unique
+class LoggingFilters(Enum):
+    """ Identifiers to coherently map elements in LocalContext.filters to filter classes. """
+
+    DEBUG_TRUE: str = 'require_debug_true'
+    DEBUG_FALSE: str = 'require_debug_false'
+    NAMES: str = 'app_filter'
+    SESSION_USER: str = 'user_filter'
+
+
+@dataclass
+class LocalContext:
+    level: str  # 'DEBUG', 'INFO' etc.
+    format: str  # logging format string (using style '{')
+    app_name: str  # the name of the application
+    app_debug: bool  # Is the app in debug mode? Corresponding to current_app.debug
+    # optionally filter debug messages to only be emitted if eppn is in this list
+    debug_eppns: Sequence[str] = field(default_factory=list)
+    filters: List[LoggingFilters] = field(default_factory=list)  # filters to activate
+    relative_time: bool = False  # use relative time as {asctime}
+
+    def to_dict(self) -> Dict[str, Any]:
+        res = asdict(self)
+        res['level'] = logging.getLevelName(self.level)
+        return res
+
+
+def make_local_context(app: EduIDBaseApp) -> LocalContext:
+    """
+    Local context is a place to put parameters for filters and formatters in logging dictConfigs.
+
+    To provide typing and order, we keep them in a neat dataclass.
+    """
+    log_format = app.config.log_format
+    if not log_format:
+        log_format = DEFAULT_FORMAT
+
+    log_level = app.config.log_level
     if app.debug:
         # Flask expects to be able to debug log in debug mode
-        local_context['level'] = 'DEBUG'
+        log_level = 'DEBUG'
 
-    settings_config = app.config.logging_config
+    filters = [LoggingFilters.NAMES, LoggingFilters.SESSION_USER]
+
+    relative_time = app.config.testing
+
+    try:
+        local_context = LocalContext(
+            level=log_level,
+            format=log_format,
+            app_name=app.name,
+            app_debug=app.debug,
+            debug_eppns=app.config.debug_eppns,
+            filters=filters,
+            relative_time=relative_time,
+        )
+    except (KeyError, AttributeError) as e:
+        raise BadConfiguration(message=f'Could not initialize logging local_context. {type(e).__name__}: {e}')
+    return local_context
+
+
+def make_dictConfig(local_context: LocalContext) -> Dict[str, Any]:
+    """
+    Create configuration for logging.dictConfig.
+
+    Anything that needs to be parameterised should be put in LocalContext, which is
+    a place to put arguments to various filters/formatters as well as anything else we
+    need.
+    """
+
+    _available_filters = {
+        # A filter that adds various hostname/container name information to the log records
+        LoggingFilters.NAMES: {'()': 'eduid_common.api.logging.AppFilter', 'app_name': 'cfg://local_context.app_name',},
+        # Only log debug messages if Flask app.debug is False
+        LoggingFilters.DEBUG_FALSE: {
+            '()': 'eduid_common.api.logging.RequireDebugFalse',
+            'app_debug': 'cfg://local_context.app_debug',
+        },
+        # Only log debug messages if Flask app.debug is True
+        LoggingFilters.DEBUG_TRUE: {
+            '()': 'eduid_common.api.logging.RequireDebugTrue',
+            'app_debug': 'cfg://local_context.app_debug',
+        },
+        # A filter that adds relative time to the log records
+        LoggingFilters.SESSION_USER: {
+            '()': 'eduid_common.api.logging.UserFilter',
+            'debug_eppns': 'cfg://local_context.debug_eppns',
+        },
+    }
+
+    # Choose filters. Technically, they could all be included always,
+    # since they have to appear in the 'filters' list of a handler in order to
+    # be invoked, but we only include the requested ones for tidiness and readability.
+    filters = {k: v for k, v in _available_filters.items() if k in local_context.filters}
+
     base_config = {
         'version': 1,
         'disable_existing_loggers': False,
         # Local variables
-        'local_context': local_context,
+        'local_context': local_context.to_dict(),
+        # Formatters
         'formatters': {
             'default': {
                 '()': 'eduid_common.api.logging.EduidFormatter',
+                'relative_time': 'cfg://local_context.relative_time',
                 'fmt': 'cfg://local_context.format',
-                'style': '{',
             },
         },
-        'filters': {
-            'app_filter': {'()': 'eduid_common.api.logging.AppFilter', 'app_name': 'cfg://local_context.app_name',},
-            'user_filter': {
-                '()': 'eduid_common.api.logging.UserFilter',
-                'debug_eppns': 'cfg://local_context.debug_eppns',
-            },
-            'require_debug_true': {
-                '()': 'eduid_common.api.logging.RequireDebugTrue',
-                'app_debug': 'cfg://local_context.app_debug',
-            },
-            'require_debug_false': {
-                '()': 'eduid_common.api.logging.RequireDebugFalse',
-                'app_debug': 'cfg://local_context.app_debug',
-            },
-            'debugtime_filter': {'()': 'eduid_common.api.logging.DebugTimeFilter',},
-        },
+        # Filters
+        'filters': filters,
+        # Handlers
         'handlers': {
             'console': {
                 'class': 'logging.StreamHandler',
                 'level': 'cfg://local_context.level',
                 'formatter': 'default',
-                'filters': ['app_filter', 'user_filter', 'debugtime_filter'],
+                'filters': local_context.filters,
             },
         },
+        # Loggers
         'root': {'handlers': ['console'], 'level': 'cfg://local_context.level',},
     }
-    logging_config = merge_config(base_config, settings_config)
-    logging.config.dictConfig(logging_config)
-    if app.debug:
-        pp = PrettyPrinter()
-        app.logger.debug(f'Logging config:\n{pp.pformat(logging_config)}')
-    app.logger.info('Logging configured')
-    return None
+    return base_config


### PR DESCRIPTION
- Separate creation of local context and dictConfig from Flask logging
setup, in order to allow configuring a logger earlier in test cases to
  get logs from before the Flask app is initialised too (test setup
  etc.).

- Merge the debugTime filter functionality into the time formatting done
  by the EduidFormatter. This removes one more special attribute on the
log records, and simplifies format configuration since we can just use
  {asctime} everywhere.

 - Make a typed dataclass LocalContext to keep all parameters for filters
  etcetera nice and tidy. The function make_local_context() initialises
  a LocalContext using the configuration of an EduidBaseApp like before,
  but e.g. test cases or non-flask-apps can instantiate a LocalContext
  themselves however they please.

- Add documentation and comments.