### PR TITLE
Remove eduPersonScopedAffiliation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 from setuptools import setup, find_packages
 
 
-version = '0.21.0'
-
+version = '0.22.0'
 
 
 requires = [

--- a/src/eduid_common/config/idp.py
+++ b/src/eduid_common/config/idp.py
@@ -149,9 +149,6 @@ class IdPConfig(BaseConfig):
     # After this time, login cannot complete because the SAMLRequest, RelayState
     # and possibly other needed information will be forgotten.
     login_state_ttl: int = 5
-    # Add a default eduPersonScopedAffiliation if none is returned from the
-    # attribute manager.
-    default_scoped_affiliation: Optional[str] = None
     # URL to use with VCCS client. BCP is to have an nginx or similar on
     # localhost that will proxy requests to a currently available backend
     # using TLS.


### PR DESCRIPTION
According to the policy we are not allowed to assert affiliate@eduid.se
as the user has no affiliation with eduID.